### PR TITLE
feat: add interactive graphics showcase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.0",
         "clsx": "^2.1.1",
+        "postprocessing": "^6.35.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "three": "^0.165.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -21,6 +23,7 @@
         "@types/node": "^20.12.7",
         "@types/react": "^18.2.46",
         "@types/react-dom": "^18.2.18",
+        "@types/three": "^0.165.0",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
         "@vitejs/plugin-react-swc": "^3.6.0",
@@ -1486,6 +1489,13 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1544,6 +1554,34 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.165.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.165.0.tgz",
+      "integrity": "sha512-AJK8JZAFNBF0kBXiAIl5pggYlzAGGA8geVYQXAcPCEDRbyA+oEjkpUBcJJrtNz6IiALwzGexFJGZG2yV3WsYBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.1",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.23.tgz",
+      "integrity": "sha512-GPe4AsfOSpqWd3xA/0gwoKod13ChcfV67trvxaW2krUbgb9gxQjnCx8zGshzMl8LSHZlNH5gQ8LNScsDuc7nGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -3719,6 +3757,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5092,6 +5137,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -5667,6 +5719,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postprocessing": {
+      "version": "6.37.8",
+      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.37.8.tgz",
+      "integrity": "sha512-qTFUKS51z/fuw2U+irz4/TiKJ/0oI70cNtvQG1WxlPKvBdJUfS1CcFswJd5ATY3slotWfvkDDZAsj1X0fU8BOQ==",
+      "license": "Zlib",
+      "peerDependencies": {
+        "three": ">= 0.157.0 < 0.181.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -6612,6 +6673,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.165.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
+      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
     "clsx": "^2.1.1",
+    "postprocessing": "^6.35.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "three": "^0.165.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -29,6 +31,7 @@
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.46",
     "@types/react-dom": "^18.2.18",
+    "@types/three": "^0.165.0",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "@vitejs/plugin-react-swc": "^3.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 import { CapabilityGrid } from "./components/CapabilityGrid";
 import { ExperienceCenter } from "./components/ExperienceCenter";
 import { Footer } from "./components/Footer";
+import { GraphicsShowcase } from "./components/GraphicsShowcase";
 import { Header } from "./components/Header";
 import { Hero } from "./components/Hero";
 import { Insights } from "./components/Insights";
@@ -16,6 +17,7 @@ export const App: FC = () => (
     <Header />
     <main id="main-content">
       <Hero />
+      <GraphicsShowcase />
       <CapabilityGrid
         id="analytics"
         title="Command Center"

--- a/src/components/GraphicsShowcase.tsx
+++ b/src/components/GraphicsShowcase.tsx
@@ -1,0 +1,322 @@
+import {
+  BlendFunction,
+  BloomEffect,
+  ChromaticAberrationEffect,
+  DepthOfFieldEffect,
+  EffectComposer,
+  EffectPass,
+  NoiseEffect,
+  RenderPass,
+  VignetteEffect,
+} from "postprocessing";
+import { useEffect, useRef } from "react";
+import {
+  AdditiveBlending,
+  AmbientLight,
+  BufferGeometry,
+  Clock,
+  Color,
+  FogExp2,
+  Float32BufferAttribute,
+  InstancedMesh,
+  Matrix4,
+  MeshBasicMaterial,
+  PerspectiveCamera,
+  Points,
+  PointsMaterial,
+  Quaternion,
+  Scene,
+  SphereGeometry,
+  SRGBColorSpace,
+  Vector2,
+  Vector3,
+  WebGLRenderer,
+  ACESFilmicToneMapping,
+} from "three";
+
+import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
+import styles from "../styles/GraphicsShowcase.module.css";
+
+const PALETTE = [
+  new Color("#bf5700"),
+  new Color("#0b1b3a"),
+  new Color("#92140c"),
+  new Color("#0f4c81"),
+];
+
+const TEAM_BANDS = [
+  new Color("#fdd6b5"),
+  new Color("#1a2a5a"),
+  new Color("#d1495b"),
+  new Color("#1c335f"),
+];
+
+const PARTICLE_COUNT = 3200;
+const TRAIL_COUNT = 180;
+
+const supportsWebGL = (): boolean => {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const canvas = document.createElement("canvas");
+  const context =
+    canvas.getContext("webgl2", { failIfMajorPerformanceCaveat: true }) ??
+    canvas.getContext("webgl", { failIfMajorPerformanceCaveat: true });
+
+  return context !== null;
+};
+
+export const GraphicsShowcase = (): JSX.Element => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    if (prefersReducedMotion || !supportsWebGL()) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const renderer = new WebGLRenderer({
+      antialias: true,
+      alpha: true,
+      powerPreference: "high-performance",
+    });
+    renderer.outputColorSpace = SRGBColorSpace;
+    renderer.toneMapping = ACESFilmicToneMapping;
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setClearColor(new Color("#05070b"), 0);
+
+    const scene = new Scene();
+    scene.fog = new FogExp2("#05070b", 0.55);
+
+    const camera = new PerspectiveCamera(55, 1, 0.1, 100);
+    camera.position.set(0, 1.3, 4.2);
+
+    const ambientLight = new AmbientLight("#ffffff", 0.8);
+    scene.add(ambientLight);
+
+    const composer = new EffectComposer(renderer);
+    composer.addPass(new RenderPass(scene, camera));
+
+    const bloom = new BloomEffect({
+      intensity: 1.1,
+      mipmapBlur: true,
+      luminanceThreshold: 0.2,
+    });
+    const chromaticAberration = new ChromaticAberrationEffect({
+      offset: new Vector2(0.0012, 0.0014),
+      radialModulation: true,
+      modulationOffset: 0.85,
+    });
+    const dof = new DepthOfFieldEffect(camera, {
+      focusDistance: 0.012,
+      focalLength: 0.037,
+      bokehScale: 2.3,
+    });
+    const grain = new NoiseEffect({
+      blendFunction: BlendFunction.SCREEN,
+      premultiply: true,
+    });
+    const vignette = new VignetteEffect({
+      eskil: false,
+      offset: 0.3,
+      darkness: 0.9,
+    });
+
+    composer.addPass(new EffectPass(camera, bloom, chromaticAberration, dof, grain, vignette));
+
+    const particleGeometry = new BufferGeometry();
+    const particlePositions = new Float32Array(PARTICLE_COUNT * 3);
+    const particleColors = new Float32Array(PARTICLE_COUNT * 3);
+    const tempColor = new Color();
+
+    for (let i = 0; i < PARTICLE_COUNT; i += 1) {
+      const radius = Math.random() * 3.4;
+      const angle = Math.random() * Math.PI * 2;
+      const height = (Math.random() - 0.5) * 2.4;
+
+      particlePositions[i * 3] = Math.cos(angle) * radius;
+      particlePositions[i * 3 + 1] = height;
+      particlePositions[i * 3 + 2] = Math.sin(angle) * radius;
+
+      tempColor.copy(PALETTE[i % PALETTE.length]);
+      tempColor.offsetHSL((Math.random() - 0.5) * 0.05, 0, 0);
+      tempColor.toArray(particleColors, i * 3);
+    }
+
+    particleGeometry.setAttribute("position", new Float32BufferAttribute(particlePositions, 3));
+    particleGeometry.setAttribute("color", new Float32BufferAttribute(particleColors, 3));
+
+    const particleMaterial = new PointsMaterial({
+      size: 0.035,
+      vertexColors: true,
+      depthWrite: false,
+      transparent: true,
+      opacity: 0.95,
+      blending: AdditiveBlending,
+    });
+
+    const particles = new Points(particleGeometry, particleMaterial);
+    scene.add(particles);
+
+    const trailGeometry = new SphereGeometry(0.03, 12, 12);
+    const trailMaterial = new MeshBasicMaterial({
+      color: "#bfd3ff",
+      transparent: true,
+      opacity: 0.6,
+    });
+    const trailMesh = new InstancedMesh(trailGeometry, trailMaterial, TRAIL_COUNT);
+    const trailMatrix = new Matrix4();
+    const trailBasePositions: Vector3[] = [];
+    const trailPhase: number[] = [];
+    const trailScale = new Vector3(1, 1, 1);
+    const trailQuaternion = new Quaternion();
+    const trailTempPosition = new Vector3();
+
+    for (let i = 0; i < TRAIL_COUNT; i += 1) {
+      const base = new Vector3((Math.random() - 0.5) * 2.6, Math.random() * 1.2, (Math.random() - 0.5) * 2.6);
+      trailBasePositions.push(base);
+      trailPhase.push(Math.random() * Math.PI * 2);
+      trailMatrix.compose(base, trailQuaternion, trailScale);
+      trailMesh.setMatrixAt(i, trailMatrix);
+    }
+    scene.add(trailMesh);
+
+    const leagueBands = TEAM_BANDS.map((color, index) => {
+      const geometry = new SphereGeometry(1.2 + index * 0.22, 48, 48);
+      const material = new PointsMaterial({
+        size: 0.04,
+        color,
+        transparent: true,
+        opacity: 0.35,
+        depthWrite: false,
+      });
+      const mesh = new Points(geometry, material);
+      scene.add(mesh);
+      return mesh;
+    });
+
+    const pointer = new Vector2();
+    const clock = new Clock();
+    let animationFrame = 0;
+
+    const resize = () => {
+      if (!container) {
+        return;
+      }
+      const { clientWidth, clientHeight } = container;
+      camera.aspect = clientWidth / clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(clientWidth, clientHeight);
+      composer.setSize(clientWidth, clientHeight);
+    };
+
+    resize();
+    container.appendChild(renderer.domElement);
+
+    const handlePointer = (event: PointerEvent) => {
+      const bounds = container.getBoundingClientRect();
+      pointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
+      pointer.y = -(((event.clientY - bounds.top) / bounds.height) * 2 - 1);
+    };
+
+    container.addEventListener("pointermove", handlePointer);
+
+    const animate = () => {
+      const elapsed = clock.getElapsedTime();
+      const delta = clock.getDelta();
+
+      particles.rotation.y += delta * 0.15;
+      particles.rotation.x = Math.sin(elapsed * 0.15) * 0.12;
+
+      const positionsAttribute = particleGeometry.getAttribute("position") as Float32BufferAttribute;
+      for (let i = 0; i < PARTICLE_COUNT; i += 1) {
+        const ix = i * 3;
+        const wave = Math.sin(elapsed * 0.8 + positionsAttribute.getY(i) * 2.1 + pointer.x * 3.2);
+        const sway = Math.cos(elapsed * 0.6 + positionsAttribute.getX(i) * 1.7 + pointer.y * 2.4);
+        positionsAttribute.array[ix + 2] += wave * 0.0009;
+        positionsAttribute.array[ix] += sway * 0.0007;
+      }
+      positionsAttribute.needsUpdate = true;
+
+      leagueBands.forEach((band, index) => {
+        band.rotation.y = elapsed * (0.08 + index * 0.03);
+        band.rotation.z = elapsed * 0.04;
+      });
+
+      for (let i = 0; i < TRAIL_COUNT; i += 1) {
+        const base = trailBasePositions[i];
+        const phase = trailPhase[i];
+        trailTempPosition.set(
+          base.x + Math.sin(elapsed * 0.5 + phase) * 0.18,
+          base.y + Math.cos(elapsed * 0.8 + phase) * 0.12,
+          base.z + Math.sin(elapsed * 0.6 + phase * 1.2) * 0.16,
+        );
+        trailMatrix.compose(trailTempPosition, trailQuaternion, trailScale);
+        trailMesh.setMatrixAt(i, trailMatrix);
+      }
+      trailMesh.instanceMatrix.needsUpdate = true;
+
+      camera.position.x += (pointer.x * 0.6 - camera.position.x) * 0.04;
+      camera.position.y += (1.2 + pointer.y * 0.4 - camera.position.y) * 0.04;
+      camera.lookAt(0, 0.4, 0);
+
+      composer.render();
+      animationFrame = requestAnimationFrame(animate);
+    };
+
+    animationFrame = requestAnimationFrame(animate);
+    window.addEventListener("resize", resize);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      window.removeEventListener("resize", resize);
+      container.removeEventListener("pointermove", handlePointer);
+      if (renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement);
+      }
+      composer.dispose();
+      renderer.dispose();
+      particleGeometry.dispose();
+      particleMaterial.dispose();
+      leagueBands.forEach((band) => {
+        band.geometry.dispose();
+        const material = band.material;
+        if (Array.isArray(material)) {
+          material.forEach((entry) => entry.dispose());
+        } else {
+          material.dispose();
+        }
+      });
+      trailMesh.dispose();
+      trailGeometry.dispose();
+      trailMaterial.dispose();
+    };
+  }, [prefersReducedMotion]);
+
+  return (
+    <section
+      id="graphics"
+      className={styles.wrapper}
+      aria-labelledby="graphics-showcase-heading"
+      data-testid="graphics-showcase"
+    >
+      <div className={styles.copy}>
+        <p className={styles.kicker}>Cinematic Intelligence</p>
+        <h2 id="graphics-showcase-heading" className={styles.title}>
+          Championship visuals rendered live in the Blaze Intelligence command center.
+        </h2>
+        <p className={styles.subtitle}>
+          HDR tone mapping, volumetric particles, and interactive camera parallax deliver the
+          broadcast polish our analysts expect across Baseball, Football, Basketball, and Track & Field.
+        </p>
+      </div>
+      <div className={styles.viewport} ref={containerRef} role="presentation" aria-hidden="true" />
+    </section>
+  );
+};

--- a/src/components/__tests__/GraphicsShowcase.test.tsx
+++ b/src/components/__tests__/GraphicsShowcase.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GraphicsShowcase } from "../GraphicsShowcase";
+
+describe("GraphicsShowcase", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "matchMedia").mockImplementation((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)" ? false : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList));
+
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders copy for the cinematic showcase", () => {
+    render(<GraphicsShowcase />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /championship visuals rendered live/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Baseball, Football, Basketball, and Track & Field/i)).toBeVisible();
+  });
+});

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+/**
+ * React hook for reading the user's reduced motion preference in a safe way.
+ */
+export const usePrefersReducedMotion = (): boolean => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(query.matches);
+
+    const listener = (event: MediaQueryListEvent): void => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    // Older Safari versions require addListener/removeListener.
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", listener);
+      return () => {
+        query.removeEventListener("change", listener);
+      };
+    }
+
+    query.addListener(listener);
+    return () => {
+      query.removeListener(listener);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+};

--- a/src/styles/GraphicsShowcase.module.css
+++ b/src/styles/GraphicsShowcase.module.css
@@ -1,0 +1,72 @@
+.wrapper {
+  display: grid;
+  gap: clamp(2rem, 3vw, 3.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  padding: clamp(3rem, 6vw, 6rem) clamp(1.5rem, 5vw, 4rem);
+  background: radial-gradient(circle at 20% 20%, rgba(191, 87, 0, 0.18), rgba(5, 7, 11, 0.9)),
+    linear-gradient(135deg, rgba(10, 15, 24, 0.95), rgba(5, 7, 11, 0.98));
+  border-radius: 32px;
+  border: 1px solid rgba(191, 87, 0, 0.35);
+  box-shadow: 0 32px 64px rgba(0, 0, 0, 0.45);
+  position: relative;
+  overflow: hidden;
+}
+
+.copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  color: #eef3ff;
+}
+
+.kicker {
+  letter-spacing: 0.4em;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(191, 87, 0, 0.8);
+}
+
+.title {
+  font-size: clamp(1.75rem, 2.6vw, 2.8rem);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0;
+  color: rgba(237, 240, 247, 0.78);
+  font-size: 1rem;
+  max-width: 42ch;
+}
+
+.viewport {
+  aspect-ratio: 4 / 3;
+  min-height: 320px;
+  width: 100%;
+  border-radius: 24px;
+  border: 1px solid rgba(237, 240, 247, 0.12);
+  background: radial-gradient(circle at center, rgba(191, 87, 0, 0.35), rgba(4, 6, 10, 0.95));
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.viewport canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: inherit;
+}
+
+@media (max-width: 768px) {
+  .wrapper {
+    padding: 2.5rem 1.5rem;
+  }
+
+  .title {
+    font-size: 1.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Three.js-driven graphics showcase with bloom, depth of field, and interactive camera motion
- add a reusable reduced-motion hook and cinematic styling for the new section
- wire up vitest coverage and install three/postprocessing typings to keep builds green

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d538153d68833080f1b3bb9b807721