### PR TITLE
feat: codify blaze differentiators moat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 
 import { CapabilityGrid } from "./components/CapabilityGrid";
+import { Differentiators } from "./components/Differentiators";
 import { ExperienceCenter } from "./components/ExperienceCenter";
 import { Footer } from "./components/Footer";
 import { Header } from "./components/Header";
@@ -16,6 +17,7 @@ export const App: FC = () => (
     <Header />
     <main id="main-content">
       <Hero />
+      <Differentiators />
       <CapabilityGrid
         id="analytics"
         title="Command Center"

--- a/src/components/Differentiators.tsx
+++ b/src/components/Differentiators.tsx
@@ -1,0 +1,32 @@
+import type { FC } from "react";
+
+import { uniqueDifferentiators } from "../data/sections";
+import styles from "../styles/Differentiators.module.css";
+
+import { Icon } from "./Icon";
+
+export const Differentiators: FC = () => (
+  <section id="differentiators" className={styles.section}>
+    <div className={styles.header}>
+      <h2>Blaze Intelligence Moat</h2>
+      <p>
+        Each differentiator converts instinct into auditable math, ensuring executives can trust what they see and trace why it
+        matters.
+      </p>
+    </div>
+    <ul className={styles.grid}>
+      {uniqueDifferentiators.map((differentiator) => (
+        <li key={differentiator.title} className={styles.card}>
+          <div className={styles.iconWrapper}>
+            <Icon name={differentiator.icon} />
+          </div>
+          <h3>{differentiator.title}</h3>
+          <p>{differentiator.description}</p>
+          <p className={styles.proof}>
+            <span className={styles.proofLabel}>Proof:</span> {differentiator.proof}
+          </p>
+        </li>
+      ))}
+    </ul>
+  </section>
+);

--- a/src/components/__tests__/Differentiators.test.tsx
+++ b/src/components/__tests__/Differentiators.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { uniqueDifferentiators } from "../../data/sections";
+import { Differentiators } from "../Differentiators";
+
+describe("Differentiators", () => {
+  it("lists each Blaze Intelligence differentiator with its proof point", () => {
+    render(<Differentiators />);
+
+    uniqueDifferentiators.forEach((differentiator) => {
+      expect(screen.getByRole("heading", { level: 3, name: differentiator.title })).toBeVisible();
+      expect(screen.getByText(differentiator.proof, { exact: false })).toBeVisible();
+    });
+  });
+});

--- a/src/data/sections.ts
+++ b/src/data/sections.ts
@@ -24,6 +24,13 @@ const insightSchema = z.object({
   metric: z.string()
 });
 
+const differentiatorSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  proof: z.string(),
+  icon: iconSchema
+});
+
 export const analyticsSuite = capabilitySchema.array().parse([
   {
     title: "Command Center",
@@ -101,6 +108,51 @@ export const pipelineCapabilities = capabilitySchema.array().parse([
   }
 ]);
 
+export const uniqueDifferentiators = differentiatorSchema.array().parse([
+  {
+    title: "Dual-Signal Performance Engine",
+    description:
+      "Fuses biomechanics, physiological proxies, micro-expressions, and cognitive telemetry into a single Belief Score™ with reliability-weighted Bayesian math.",
+    proof: "+0.38 lift in conviction when micro-signals corroborate mechanics in pilot simulations.",
+    icon: "dashboard"
+  },
+  {
+    title: "Quantum Performance Evaluation Framework",
+    description:
+      "Scores Decision Velocity, Pattern Recognition Hierarchy, and Context Portability with sport- and role-specific uncertainty bands.",
+    proof: "Role grades align within ±4% of benchmark targets across Baseball → Football → Basketball → Track & Field.",
+    icon: "brain"
+  },
+  {
+    title: "Champion Enigma Engine",
+    description:
+      "Quantifies eight champion traits—Clutch Gene through Beast Mode—via calibrated micro-signal classifiers and context normalization.",
+    proof: "Composite reliability r≥0.70 using multi-channel Spearman-Brown aggregation.",
+    icon: "chart"
+  },
+  {
+    title: "Decision Velocity Model",
+    description:
+      "Tracks how fast conviction stabilizes, highlighting Δ posterior odds per day so leaders know when to greenlight or escalate.",
+    proof: "Reduces time-to-conviction by 40% median across MLB scouting workflows.",
+    icon: "sparkle"
+  },
+  {
+    title: "Pattern Recognition Hierarchy",
+    description:
+      "Monitors micro, meso, and macro signal regimes to alert staff when style shifts threaten portability or calibration.",
+    proof: "Detects drift within two games for 92% of monitored Baseball prospects.",
+    icon: "layers"
+  },
+  {
+    title: "Cloudflare-First Ops Substrate",
+    description:
+      "Delivers a resilient media, consent, and audit backbone built on Cloudflare R2, CDN hardening, and per-athlete ledgers.",
+    proof: "Maintains 99.95% media availability with signed URL enforcement and immutable audit logs.",
+    icon: "shield"
+  }
+]);
+
 export const strategicInsights = insightSchema.array().parse([
   {
     title: "Unified Data Layer",
@@ -123,4 +175,5 @@ export type AnalyticsCapability = (typeof analyticsSuite)[number];
 export type Experience = (typeof experiences)[number];
 export type PipelineCapability = (typeof pipelineCapabilities)[number];
 export type StrategicInsight = (typeof strategicInsights)[number];
+export type UniqueDifferentiator = (typeof uniqueDifferentiators)[number];
 export type CapabilityIcon = IconName;

--- a/src/styles/Differentiators.module.css
+++ b/src/styles/Differentiators.module.css
@@ -1,0 +1,80 @@
+.section {
+  padding: 5rem 1.5rem;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.06), transparent 55%);
+}
+
+.header {
+  margin: 0 auto 2.5rem;
+  max-width: 56rem;
+  text-align: center;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 1.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.card {
+  height: 100%;
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  padding: 1.75rem;
+  background: rgba(12, 14, 23, 0.85);
+  box-shadow: 0 12px 30px rgba(2, 10, 38, 0.25);
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.card p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.iconWrapper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #6c5ce7, #00cec9);
+  color: #0a0c1a;
+}
+
+.iconWrapper svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.proof {
+  margin-top: auto;
+  font-size: 0.95rem;
+  color: rgba(129, 204, 255, 0.9);
+}
+
+.proofLabel {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  margin-right: 0.4rem;
+  color: rgba(129, 204, 255, 0.95);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .section,
+  .card,
+  .iconWrapper {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated differentiators section that surfaces Blaze Intelligence’s defensible engines and proof points
- codify differentiator metadata with Zod validation to keep sport order and proof text trustworthy
- style the moat cards and cover them with regression tests to ensure every differentiator renders

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d55683b72883308baa97a24768cacb