### PR TITLE
feat: improve dashboard accessibility and performance

### DIFF
--- a/blaze-unified/blaze-unified/web/index.html
+++ b/blaze-unified/blaze-unified/web/index.html
@@ -1,0 +1,2673 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blaze Intelligence | Championship Sports MCP</title>
+    <meta name="description" content="Championship-grade Mission Command Platform for sports intelligence, delivering next-level NIL analytics, AI-driven scouting, biomechanics simulation, and real-time insights for elite programs.">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACxMAAAsTAQCanBgAAAdASURBVHhe7Vt7bBRVGP/9R+AioCgU8VFAoUeFApUiAhLxAU/UqIGgCIpE8dGgxigkokc0RBJfQI3RoPGBoDFGExX9oBGEoEaN8YBo/KCCGB8t1EqlhYp1QJb9mdl/s2+77e5c+yv5JMl2985835nvzDlnZodIHDv2+PHjV6+pqanvBA9g8Pjx460gJ221tbWX1tbWXkK04cOHD68mJWgVBAx5eXlfnz59OhQEsrq6+is1+PLly+X19fV3sR9gJ22DBw/eV1ZW9oP/j/c4efLkbwkJCa8hWvD8+fOVCQsLC4EAnpyc/F5aWvoTGoBiaGhoKSkpicCfP3++JSkp6X5UAOpiGhoa/hV19/b2XgYEBPwKCcCfP39eERIScl1eXv4VHYB+hIWFvXv8+PErCAQ4d+7cB2VlZf3gH+DcuXPPysrKagH46dOnrUuXLj0fFAB+hISElJSUFD/gA8CfP39+j4iI6BsagP6Kior78uXLlX9APwDBA6CdnZ0vBQUFrwIBfPv27a2wsPDjQABQ0dLS8lFeXv4eAnwB+Pz58xeCg4P/AwVAQUtLy1X5+fkfhgTgl5eXl9va2q4CAUAZDAwMfAwJQNwBCgD68+fPj0NDQ5+CAHDp0qVzpaWlvwQDoAyoAJS1tbXPhgTgn5iY+FlYWPgbKABKGRkZvwoL4M+fP7/d2dl5IRSAAg4cOPElJASgD6ABKGVoaOgLEID/mZkZpAUo4Pjx41eRkZEH0ABUwpOTE7SAAg4dOvSOiAjQAKgASkpKclCAgoKC3gQD0AA0AD09PW8CAejTp0+/BwVAQXV19TcQgLpAPwDBAzgD0ABUVlZW/4IE4J87d25bVFT0IRQAdeHi4uJ3kAB+f3//3QBAXUADUENDQwOAAOr6/v37H6ADKC4uvgoI4CcnJ28EAKBrAwMDHwIB/MvLy7cGAKArhIWFvYtPgP779++vBAVAXYWGhv4W+gD66dOnb6ADKCgo6A3wEaBv3779IRgAdQ0LC3sPDgAdQHFx8VUIAOqKuro6WIAA9AYCgK59+/bt/gQJoB9AASgpKckDQgD1gQGgK59//vmr+AnQf/z48QdQAJSWln4CCeA/d+7cC+AA6MpCQkJeQwrQT548eQEVAJWWlr4HCeAPDQ1dDAVAXR/D99/AwXgZ2dn/woFoK51dHTcDAngW7dufQgKoC5BQUEfAgHoAygASklJcSfA/33//v2PoACoYWBg4AtoAPqJEyc+BgVAXQICAj4FCeB3d3dPBgVAXZWXl38LEkADUAWgpqbmjQBAXaGhofE1kAD9zZs3rwIBoCv9A9DffvvtP1ABqAsICPhVTAA/NDT0lVAA1AUEBPwM7AP09evXbwQFQF1FRUV8BT4D/I2NjQ8BAaDrw4cPbxQngD58+PAFUAColpaWzwYC+C1btjwdCEDdAgICfokKoKenp2/AAKgXFBQU5G/evPkyJICfn59/EQxA3QICAv6L2AD95cuXr4EBoAsfPXr0nUgA/unp6beDAKAbL168+A8SgH50dPREUAB0Q0VFxc8QAP3NmzevAAGgGz4+Pv4r0A/QUaAD6Jquri5QAPRLS0u/AwGgm8LCwl5DAdAfHx/fAwVAX+np6T8DAaAbb9++fRoSQF9ZWfnBwAD68u/fv0/CAgD60tDQ8DskgL4EBQUdDgagn/379+/T8BHwDw4O3gwGoJ8MDAz8CPQJ0F9fX/+VagH6y7Nnz15BAsgnT578DgzATzC+vr5+eXh4eGv4AuiLjY3tHhkZ2U8B9gH83/n3d3T+QcTHx3+dnp7+oT4A/vFqamreRERE/AIBoE/Pnz9f6e/vvxT0A/TPnj37Jj4+/jMEgnz48OGVpKSk/qEB0Pf09PySnp6+E3gA/eXNmzc/x8bG/hL0A/SvX7/+T0ZGxhcQCHLixIkfU1NTv0QD0F9eXv7LysoKfhR8AP3t27c/hoaGfg36h2Y+ffp0dHZ2/jsQCHLk+s2bN/9GBqBv27ZtE9b+Af2/e/funwkJCV+D/mGY3759e5Geni4Egnz48OGV+Pj4T6EB6Pvp06c/xMfHnwI/QX/79u3/ExMTfwL9g+L//v37e3V19XdAINAF4NOnT/8cDQB98E9BfwT9h+W/f//++7S0tD+B/iH2H/r/kS+ATgBOAJ0AnAC6AE6ePPk7Ojp61f8P5f/x48evW7du/RsGgN4fPnzwF+gD6O3tvaejo+MvEAh0AfgT0w/x7du3/xkGgF5DQ0PD4uLiYhCADgD6g/J/X15e/goJoBPAV69e/T44OPgLDICenJz8Znx8fD94ADoB/OHDh1fS0tJ2gQGgZ2Bg4PdkZGT8AAVAIaBfsM3NzZ+BgQB0Bf4t0wD0mzdvHkNDQ/2gAKiqqKjoA+gE6Ldu3Qp1AOiRkZExaGho+AWkAYC64sWLF/+Vlpa2A/0Aen9//93p6ekf0ADUCgoK+tXV1SXuB+hLS0u/AwEAdRUVFX1aWlra+AP0S0pKchAagOrR0dF9oQCovqioaA9IAKg3MzPzKyiASkpKclCA6oODgzcDAYD6y5cvfw0KoG5SU1MPAAGgfrS0tPwKFEA11dXV+QcHgfrz58//BQpQPZKTk++AAKhuqKjowwGgfhoaGj4FCqA6Bw8ePCgsLPwgEAD1CQkJ2YECUJ1NTU1dAAKgPqSkpHgKFKBaJiYmHgACoD6EhIQcDgoAqurq6nIACIB6SEpKslCAanp6eu4BAVAfg4ODlwIFqFampqbWAwGgPiorKzMIBahWcXHxQSAA6sPi4uJjQACqKSkpSUEBoI5CQkLGAQFQTU1NTS8HBID6UFBQkP+A6gUDoC6QkJAwHwpQPSooKAgyAKjOwsLiQSAA6sPCwuLjQACqaWpqKgAFQH0MDAx8BQpQPSEhIQ8BAVAfCwuLvAQFoCqNjY0fAgKgPhYWFo4CAqCaenp6LgAColqSkpJuAoFU+z9rJ5+FwH6+tQAAAABJRU5ErkJggg==">
+
+    <!-- Three.js and Dependencies -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/postprocessing/EffectComposer.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/postprocessing/RenderPass.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/postprocessing/UnrealBloomPass.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/shaders/LuminosityHighPassShader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/shaders/CopyShader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/postprocessing/ShaderPass.js"></script>
+
+    <!-- Chart.js for Data Visualization -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+    <!-- Font -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            --burnt-orange: #BF5700;
+            --cardinal-blue: #9BCBEB;
+            --deep-navy: #002244;
+            --championship-gold: #FFD700;
+            --sec-crimson: #9E1B32;
+            --success-green: #10B981;
+            --warning-amber: #F59E0B;
+            --error-red: #EF4444;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html {
+            scroll-behavior: smooth;
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            overflow: hidden; /* Prevent scrollbars from appearing */
+            background: #000;
+            color: #fff;
+        }
+
+        /* Loading Screen */
+        .loading-screen {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(135deg, #0a0a0a 0%, #1a1a2e 100%);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            z-index: 10000;
+            transition: opacity 0.5s ease;
+        }
+
+        .loader {
+            width: 120px;
+            height: 120px;
+            border: 4px solid rgba(191, 87, 0, 0.2);
+            border-top: 4px solid var(--burnt-orange);
+            border-radius: 50%;
+            animation: spin 1s cubic-bezier(0.68, -0.55, 0.265, 1.55) infinite;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+        .loading-text {
+            margin-top: 30px;
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--cardinal-blue);
+            text-align: center;
+        }
+
+        .loading-progress {
+            margin-top: 20px;
+            width: 300px;
+            height: 4px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 2px;
+            overflow: hidden;
+        }
+
+        .loading-bar {
+            height: 100%;
+            background: linear-gradient(90deg, var(--burnt-orange), var(--championship-gold));
+            width: 0%;
+            animation: load 2s ease-in-out forwards;
+        }
+
+        @keyframes load {
+            0% { width: 0%; }
+            100% { width: 100%; }
+        }
+
+        /* Gemini AI Feature Styles */
+        .gemini-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+            width: 100%;
+            margin-top: 20px;
+            padding: 12px;
+            border: 1px solid var(--championship-gold);
+            background: rgba(255, 215, 0, 0.1);
+            color: var(--championship-gold);
+            font-weight: 600;
+            border-radius: 12px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .gemini-btn:hover:not(:disabled) {
+            background: var(--championship-gold);
+            color: #000;
+            box-shadow: 0 10px 20px rgba(255, 215, 0, 0.2);
+        }
+
+        .gemini-btn:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
+        }
+
+        .ai-content {
+            margin-top: 15px;
+            padding-top: 15px;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+            text-align: left;
+        }
+        .ai-content ul {
+            list-style-position: inside;
+            padding-left: 10px;
+        }
+        .ai-content li {
+            margin-bottom: 8px;
+        }
+
+        .strategy-step {
+            margin-bottom: 15px;
+        }
+
+        .strategy-step h4 {
+            color: var(--cardinal-blue);
+            margin-bottom: 5px;
+        }
+
+        .strategy-step p {
+            color: rgba(255, 255, 255, 0.8);
+            font-size: 0.95rem;
+        }
+
+        .spinner {
+            width: 20px;
+            height: 20px;
+            border: 2px solid currentColor;
+            border-top-color: transparent;
+            border-radius: 50%;
+            animation: spin 0.6s linear infinite;
+            display: none; /* Hidden by default */
+        }
+        
+        .gemini-btn .spinner {
+            display: none;
+        }
+        .gemini-btn.loading .spinner {
+            display: inline-block;
+        }
+        .gemini-btn.loading span {
+            display: none;
+        }
+
+        /* Mode Toggle */
+        .view-toggle {
+            display: flex;
+            background: rgba(0, 0, 0, 0.9);
+            border: 2px solid var(--burnt-orange);
+            border-radius: 50px;
+            padding: 4px;
+            backdrop-filter: blur(20px);
+        }
+
+        .mode-btn {
+            padding: 10px 20px;
+            background: transparent;
+            border: none;
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+            border-radius: 50px;
+            transition: all 0.3s ease;
+            font-size: 0.9rem;
+        }
+
+        .mode-btn.active {
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            color: #000;
+        }
+
+        /* 3D Universe Container */
+        #universe-container {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 1;
+        }
+
+        #universe-canvas {
+            width: 100%;
+            height: 100%;
+        }
+
+        /* Classic View Container */
+        #classic-container {
+            display: block;
+            position: relative;
+            width: 100%;
+            height: 100%;
+            overflow-y: auto;
+            background: linear-gradient(135deg, #0a0a0a 0%, #1a1a2e 100%);
+            z-index: 2;
+        }
+
+        /* Professional Header */
+        .header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 80px;
+            background: rgba(0, 0, 0, 0.95);
+            backdrop-filter: blur(20px);
+            border-bottom: 1px solid rgba(191, 87, 0, 0.3);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0 40px;
+            z-index: 100;
+        }
+
+        .brand-logo {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+            cursor: pointer;
+        }
+
+        .logo-icon {
+            width: 50px;
+            height: 50px;
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            border-radius: 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 900;
+            font-size: 1.5rem;
+            color: #000;
+        }
+
+        .brand-text {
+            font-size: 1.5rem;
+            font-weight: 900;
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        .brand-tagline {
+            font-size: 0.8rem;
+            color: var(--cardinal-blue);
+            font-weight: 500;
+        }
+
+        /* Navigation Menu */
+        .nav-menu {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 24px; /* Reduced gap */
+        }
+
+        .nav-links,
+        .nav-cta-group {
+            display: flex;
+            align-items: center;
+            gap: 20px; /* Reduced gap */
+        }
+
+        .nav-cta-group {
+            gap: 12px; /* Reduced gap */
+        }
+
+        .nav-item {
+            color: #fff;
+            text-decoration: none;
+            font-weight: 500;
+            transition: all 0.3s ease;
+            position: relative;
+        }
+
+        .nav-item:hover {
+            color: var(--championship-gold);
+        }
+
+        .nav-item::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--championship-gold);
+            transition: width 0.3s ease;
+        }
+
+        .nav-item:hover::after {
+            width: 100%;
+        }
+
+        .nav-cta {
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            color: #000;
+            padding: 10px 16px; /* Reduced padding */
+            border-radius: 24px;
+            font-weight: 700;
+            box-shadow: 0 12px 32px rgba(191, 87, 0, 0.35);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            transition: transform 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+        }
+
+        .nav-cta:hover {
+            color: #000;
+            transform: translateY(-2px);
+            box-shadow: 0 18px 40px rgba(191, 87, 0, 0.45);
+        }
+
+        .nav-cta::after {
+            display: none;
+        }
+
+        /* New styles for nav controls */
+        .nav-controls-group {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        /* HUD Overlay for 3D View */
+        .hud-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            pointer-events: none;
+            z-index: 50;
+        }
+
+        .hud-overlay > * {
+            pointer-events: auto;
+        }
+
+        .hud-panel {
+            position: fixed;
+            background: rgba(0, 0, 0, 0.9);
+            backdrop-filter: blur(20px);
+            border-radius: 20px;
+            padding: 30px;
+            z-index: 100;
+            opacity: 0;
+            transform: translateX(-20px) scale(0.95);
+            transition: opacity 0.5s ease, transform 0.5s ease;
+            display: none; /* Controlled by JS */
+            will-change: transform, opacity;
+        }
+        
+        .hud-panel.visible {
+            opacity: 1;
+            transform: translateX(0) scale(1);
+        }
+
+        /* Mission Statement Panel */
+        .mission-panel {
+            top: 100px;
+            left: 40px;
+            width: 400px;
+            border: 1px solid var(--burnt-orange);
+        }
+
+        .mission-title {
+            font-size: 1.8rem;
+            font-weight: 900;
+            color: var(--championship-gold);
+            margin-bottom: 15px;
+        }
+
+        .mission-text {
+            font-size: 1rem;
+            line-height: 1.6;
+            color: rgba(255, 255, 255, 0.9);
+            margin-bottom: 20px;
+        }
+
+        .mission-stats {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 15px;
+            margin-top: 20px;
+        }
+
+        .mission-stat {
+            background: rgba(191, 87, 0, 0.1);
+            padding: 15px;
+            border-radius: 10px;
+            border-left: 3px solid var(--burnt-orange);
+        }
+
+        .mission-stat-value {
+            font-size: 1.5rem;
+            font-weight: 900;
+            color: var(--championship-gold);
+        }
+
+        .mission-stat-label {
+            font-size: 0.8rem;
+            color: var(--cardinal-blue);
+            margin-top: 5px;
+        }
+        
+        /* Biomechanics HUD Panel */
+        .biomechanics-panel {
+             top: 100px;
+             left: 40px;
+             width: 400px;
+             border: 1px solid var(--cardinal-blue);
+        }
+        .biomechanics-title {
+            font-size: 1.8rem;
+            font-weight: 900;
+            color: var(--cardinal-blue);
+            margin-bottom: 20px;
+        }
+        .bio-metric {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 15px;
+            font-size: 1rem;
+        }
+        .bio-metric-label {
+            color: rgba(255, 255, 255, 0.8);
+        }
+        .bio-metric-value {
+            font-weight: 700;
+            font-size: 1.2rem;
+            color: var(--championship-gold);
+            min-width: 100px;
+            text-align: right;
+        }
+        
+        /* Program Detail Panel */
+        .detail-panel {
+            top: 100px;
+            left: 40px;
+            width: 450px;
+            border: 1px solid var(--championship-gold);
+        }
+        .detail-header {
+            display: flex;
+            align-items: center;
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+        .detail-logo {
+            width: 60px;
+            height: 60px;
+        }
+        .detail-title {
+            font-size: 1.8rem;
+            font-weight: 900;
+            color: var(--championship-gold);
+        }
+        .detail-subtitle {
+            font-size: 1rem;
+            color: var(--cardinal-blue);
+        }
+        .detail-chart-container {
+            margin: 20px 0;
+            height: 200px;
+        }
+        .detail-factors h4 {
+            font-size: 1.1rem;
+            color: var(--cardinal-blue);
+            margin-bottom: 10px;
+            border-bottom: 1px solid rgba(155, 203, 235, 0.3);
+            padding-bottom: 5px;
+        }
+        .detail-factor {
+            display: flex;
+            justify-content: space-between;
+            font-size: 0.95rem;
+            margin-bottom: 8px;
+        }
+        .detail-factor-label {
+            color: rgba(255, 255, 255, 0.8);
+        }
+        .detail-factor-value {
+            font-weight: 600;
+            text-align: right;
+        }
+        .close-btn {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            background: none;
+            border: none;
+            color: #fff;
+            font-size: 2rem;
+            cursor: pointer;
+            transition: color 0.3s ease, transform 0.3s ease;
+        }
+        .close-btn:hover {
+            color: var(--error-red);
+            transform: rotate(90deg);
+        }
+
+        /* Live Metrics Dashboard */
+        .metrics-dashboard {
+            position: fixed;
+            top: 100px;
+            right: 40px;
+            width: 350px;
+            background: rgba(0, 0, 0, 0.9);
+            backdrop-filter: blur(20px);
+            border: 1px solid var(--cardinal-blue);
+            border-radius: 20px;
+            padding: 25px;
+            z-index: 100;
+        }
+
+        .metrics-title {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: var(--cardinal-blue);
+            margin-bottom: 20px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .live-indicator {
+            width: 10px;
+            height: 10px;
+            background: var(--success-green);
+            border-radius: 50%;
+            animation: pulse 2s infinite;
+        }
+
+        @keyframes pulse {
+            0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.7); }
+            70% { box-shadow: 0 0 0 10px rgba(16, 185, 129, 0); }
+            100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+        }
+
+        .metric-item {
+            background: rgba(155, 203, 235, 0.05);
+            border-radius: 12px;
+            padding: 15px;
+            margin-bottom: 15px;
+            border: 1px solid rgba(155, 203, 235, 0.2);
+            transition: all 0.3s ease;
+        }
+
+        .metric-item:hover {
+            background: rgba(155, 203, 235, 0.1);
+            transform: translateX(5px);
+        }
+
+        .metric-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 10px;
+        }
+
+        .metric-label {
+            font-size: 0.9rem;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .metric-value {
+            font-size: 1.8rem;
+            font-weight: 900;
+            color: var(--championship-gold);
+        }
+
+        .metric-change {
+            font-size: 0.8rem;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-weight: 600;
+        }
+
+        .metric-change.positive {
+            background: rgba(16, 185, 129, 0.2);
+            color: var(--success-green);
+        }
+
+        .metric-change.negative {
+            background: rgba(239, 68, 68, 0.2);
+            color: var(--error-red);
+        }
+
+        /* Control Panel */
+        .control-panel {
+            position: fixed;
+            bottom: 40px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 15px;
+            background: rgba(0, 0, 0, 0.95);
+            backdrop-filter: blur(20px);
+            border: 1px solid var(--burnt-orange);
+            border-radius: 60px;
+            padding: 20px 40px;
+            z-index: 100;
+        }
+
+        .control-btn {
+            background: rgba(191, 87, 0, 0.1);
+            border: 1px solid var(--burnt-orange);
+            color: white;
+            padding: 12px 24px;
+            border-radius: 30px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            font-size: 0.9rem;
+        }
+
+        .control-btn:hover {
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            transform: translateY(-2px);
+            box-shadow: 0 10px 30px rgba(191, 87, 0, 0.4);
+            color: #000;
+        }
+
+        .control-btn.active {
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            color: #000;
+        }
+        
+        /* Deployment Hero */
+        .deployment-hero {
+            background: radial-gradient(circle at top left, rgba(191, 87, 0, 0.25), rgba(0, 0, 0, 0.95));
+            border: 1px solid rgba(191, 87, 0, 0.35);
+            border-radius: 30px;
+            padding: 60px;
+            margin-bottom: 60px;
+            position: relative;
+            overflow: hidden;
+            box-shadow: 0 45px 120px rgba(0, 0, 0, 0.45);
+        }
+
+        .deployment-hero::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at 80% 20%, rgba(155, 203, 235, 0.25), transparent 55%);
+            pointer-events: none;
+        }
+
+        .hero-intro {
+            max-width: 620px;
+            position: relative;
+            z-index: 1;
+        }
+
+        .deployment-hero-title {
+            font-size: 2.75rem;
+            line-height: 1.1;
+            font-weight: 900;
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            margin-bottom: 16px;
+        }
+
+        .hero-subtitle {
+            font-size: 1.1rem;
+            color: rgba(255, 255, 255, 0.75);
+        }
+
+        .hero-cta-grid {
+            position: relative;
+            z-index: 1;
+            margin-top: 40px;
+            display: grid;
+            gap: 20px;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+
+        .hero-cta {
+            --accent-color: var(--burnt-orange);
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            padding: 26px 24px;
+            border-radius: 20px;
+            background: rgba(0, 0, 0, 0.85);
+            border: 1px solid rgba(155, 203, 235, 0.25);
+            border-left: 4px solid var(--accent-color);
+            color: #fff;
+            text-decoration: none;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+            transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+        }
+
+        .hero-cta:hover {
+            transform: translateY(-6px);
+            box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+            border-color: rgba(191, 87, 0, 0.6);
+        }
+
+        .hero-cta--main {
+            --accent-color: var(--championship-gold);
+        }
+
+        .hero-cta--3d {
+            --accent-color: var(--cardinal-blue);
+        }
+
+        .hero-cta-label {
+            font-size: 1.2rem;
+            font-weight: 700;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+        }
+
+        .hero-cta-description {
+            color: rgba(255, 255, 255, 0.65);
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .hero-cta-action {
+            font-weight: 600;
+            color: var(--championship-gold);
+            font-size: 0.95rem;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .hero-cta-action::after {
+            content: '→';
+            transition: transform 0.3s ease;
+        }
+
+        .hero-cta:hover .hero-cta-action::after {
+            transform: translateX(4px);
+        }
+
+        /* Differentiators Section */
+        .deployment-differentiators {
+            margin-bottom: 70px;
+        }
+
+        .differentiator-title {
+            font-size: 2rem;
+            font-weight: 800;
+            margin-bottom: 12px;
+            text-align: center;
+        }
+
+        .differentiator-title span {
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        .differentiator-subtitle {
+            text-align: center;
+            color: rgba(255, 255, 255, 0.65);
+            max-width: 780px;
+            margin: 0 auto 40px;
+        }
+
+        .differentiator-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 24px;
+        }
+
+        .differentiator-card {
+            --accent-color: var(--burnt-orange);
+            background: rgba(0, 0, 0, 0.82);
+            border: 1px solid rgba(155, 203, 235, 0.2);
+            border-top: 4px solid var(--accent-color);
+            border-radius: 20px;
+            padding: 28px;
+            box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+
+        .differentiator-card--main {
+            --accent-color: var(--championship-gold);
+        }
+
+        .differentiator-card--3d {
+            --accent-color: var(--cardinal-blue);
+        }
+
+        .differentiator-card h3 {
+            font-size: 1.3rem;
+            font-weight: 800;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+        }
+
+        .differentiator-card p {
+            color: rgba(255, 255, 255, 0.7);
+            line-height: 1.6;
+        }
+
+        .differentiator-card ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: 10px;
+        }
+
+        .differentiator-card li {
+            position: relative;
+            padding-left: 26px;
+            color: rgba(255, 255, 255, 0.8);
+            font-size: 0.95rem;
+        }
+
+        .differentiator-card li::before {
+            content: '✓';
+            position: absolute;
+            left: 0;
+            color: var(--championship-gold);
+            font-weight: 700;
+        }
+
+        .card-link {
+            margin-top: auto;
+            color: var(--championship-gold);
+            font-weight: 600;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            letter-spacing: 0.02em;
+        }
+
+        .card-link::after {
+            content: '↗';
+            transition: transform 0.3s ease;
+        }
+
+        .card-link:hover::after {
+            transform: translate(4px, -4px);
+        }
+
+        /* Classic Dashboard Styles */
+        .classic-dashboard {
+            padding: 120px 40px 40px;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .dashboard-header {
+            text-align: center;
+            margin-bottom: 50px;
+        }
+
+        .dashboard-title {
+            font-size: 3rem;
+            font-weight: 900;
+            background: linear-gradient(135deg, var(--burnt-orange), var(--championship-gold));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            margin-bottom: 20px;
+        }
+
+        .dashboard-subtitle {
+            font-size: 1.2rem;
+            color: var(--cardinal-blue);
+        }
+
+        /* Grid Layout */
+        .dashboard-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            gap: 30px;
+            margin-bottom: 50px;
+        }
+
+        .dashboard-card {
+            background: rgba(0, 0, 0, 0.8);
+            backdrop-filter: blur(20px);
+            border: 1px solid rgba(191, 87, 0, 0.3);
+            border-radius: 20px;
+            padding: 30px;
+            transition: all 0.3s ease;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .dashboard-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 20px 40px rgba(191, 87, 0, 0.2);
+            border-color: var(--burnt-orange);
+        }
+
+        .card-title {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: var(--championship-gold);
+            margin-bottom: 20px;
+        }
+
+        .card-content {
+            color: rgba(255, 255, 255, 0.9);
+            line-height: 1.6;
+            flex-grow: 1; /* Allows card to grow */
+        }
+        
+        /* Scouting Command Center Styles */
+        .scouting-card .video-placeholder {
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            background: #111 url('https://placehold.co/600x400/000000/BF5700?text=Arch+Manning+%7C+Post+Route') no-repeat center center;
+            background-size: cover;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            margin-bottom: 20px;
+        }
+        .analysis-output {
+            text-align: left;
+            font-size: 0.95rem;
+        }
+        .analysis-output h4 {
+            color: var(--cardinal-blue);
+            font-size: 1rem;
+            margin-top: 15px;
+            margin-bottom: 5px;
+        }
+        .analysis-output ul {
+            list-style: none;
+            padding-left: 0;
+        }
+        .analysis-output li {
+            position: relative;
+            padding-left: 20px;
+            margin-bottom: 5px;
+        }
+        .analysis-output li::before {
+            position: absolute;
+            left: 0;
+            font-weight: bold;
+        }
+        .analysis-output .strength::before {
+            content: '✓';
+            color: var(--success-green);
+        }
+         .analysis-output .improvement::before {
+            content: '⚡';
+            color: var(--warning-amber);
+        }
+
+        /* Data Tables */
+        .data-table {
+            width: 100%;
+            background: rgba(0, 0, 0, 0.8);
+            border-radius: 20px;
+            overflow: hidden;
+            margin-bottom: 30px;
+        }
+
+        .table-header {
+            background: linear-gradient(135deg, var(--burnt-orange), var(--deep-navy));
+            padding: 20px;
+        }
+
+        .table-title {
+            font-size: 1.3rem;
+            font-weight: 700;
+            color: #fff;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        thead th {
+            background: rgba(191, 87, 0, 0.1);
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+            color: var(--cardinal-blue);
+            border-bottom: 2px solid var(--burnt-orange);
+        }
+
+        tbody td {
+            padding: 15px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+            color: rgba(255, 255, 255, 0.9);
+        }
+
+        tbody tr:hover {
+            background: rgba(191, 87, 0, 0.05);
+        }
+
+        /* Charts Container */
+        .charts-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+            gap: 30px;
+            margin-bottom: 50px;
+        }
+
+        .chart-card {
+            background: rgba(0, 0, 0, 0.8);
+            border: 1px solid rgba(155, 203, 235, 0.3);
+            border-radius: 20px;
+            padding: 30px;
+        }
+        .full-width-chart {
+            grid-column: 1 / -1; /* Span full width */
+        }
+        
+        /* NCAA Scoreboard Styles */
+        .ncaa-scoreboard {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+            padding: 20px;
+        }
+        .ncaa-game {
+            background: rgba(0,0,0,0.5);
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 12px;
+            padding: 20px;
+        }
+        .ncaa-game.blaze-highlight {
+            border-left: 4px solid var(--burnt-orange);
+            background: radial-gradient(circle at top left, rgba(191, 87, 0, 0.15), transparent 70%);
+        }
+        .ncaa-game-header {
+            font-size: 0.8rem;
+            color: var(--cardinal-blue);
+            margin-bottom: 15px;
+            display: flex;
+            justify-content: space-between;
+        }
+        .ncaa-team {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 1.1rem;
+            margin-bottom: 10px;
+        }
+        .ncaa-team-name {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .ncaa-team-rank {
+            font-size: 0.9rem;
+            color: rgba(255,255,255,0.6);
+        }
+        .ncaa-team-score {
+            font-weight: 900;
+            font-size: 1.5rem;
+        }
+
+        /* Player Card Modal */
+        .player-card-modal-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.8);
+            backdrop-filter: blur(10px);
+            display: none;
+            justify-content: center;
+            align-items: center;
+            z-index: 2000;
+        }
+
+        .player-card-modal {
+            background: radial-gradient(circle at top left, rgba(191, 87, 0, 0.15), #0a0a1a 70%);
+            border: 1px solid var(--burnt-orange);
+            border-radius: 24px;
+            width: 90%;
+            max-width: 600px;
+            padding: 30px;
+            position: relative;
+            animation: fadeIn 0.3s ease-out;
+        }
+        
+        .player-card-header {
+            display: flex;
+            align-items: center;
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+
+        .player-photo {
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            border: 3px solid var(--championship-gold);
+            object-fit: cover;
+        }
+
+        .player-name {
+            font-size: 2rem;
+            font-weight: 900;
+            color: var(--championship-gold);
+        }
+        
+        .player-info {
+             font-size: 1rem;
+             color: var(--cardinal-blue);
+        }
+        
+        .player-card-body {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 30px;
+        }
+        
+        .radar-chart-container {
+            position: relative;
+            height: 250px;
+        }
+
+        .player-stats h4 {
+            color: var(--cardinal-blue);
+            margin-bottom: 10px;
+        }
+
+        .player-stat {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 8px;
+            font-size: 0.95rem;
+        }
+
+        .player-stat-label { color: rgba(255,255,255,0.7); }
+        .player-stat-value { font-weight: 600; }
+
+
+        /* Mobile Responsive */
+        @media (max-width: 1200px) {
+             .nav-links {
+                display: none;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .header {
+                padding: 0 20px;
+                height: 70px;
+            }
+            .brand-text { font-size: 1.2rem; }
+            .brand-tagline { display: none; }
+            
+            .nav-menu {
+                display: none;
+            }
+
+            .deployment-hero {
+                padding: 40px 24px;
+                margin-bottom: 50px;
+            }
+
+            .deployment-hero-title {
+                font-size: 2.2rem;
+            }
+
+            .hero-cta {
+                padding: 22px 20px;
+            }
+
+            .differentiator-title {
+                font-size: 1.6rem;
+            }
+
+            .mission-panel, .biomechanics-panel, .detail-panel {
+                top: 90px;
+                left: 20px;
+                right: 20px;
+                width: auto;
+            }
+
+            .metrics-dashboard {
+                right: 20px;
+                left: 20px;
+                width: auto;
+                top: auto;
+                bottom: 120px;
+            }
+
+            .control-panel {
+                padding: 15px;
+                width: calc(100% - 40px);
+                gap: 5px;
+                overflow-x: auto;
+                justify-content: flex-start;
+            }
+            .control-btn {
+                padding: 10px 18px;
+                font-size: 0.8rem;
+                white-space: nowrap;
+            }
+
+            .dashboard-grid {
+                grid-template-columns: 1fr;
+            }
+            .charts-container {
+                 grid-template-columns: 1fr;
+            }
+        }
+
+        /* Smooth Transitions */
+        .fade-in {
+            animation: fadeIn 0.5s ease-in;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(20px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        /* Mini Map */
+        .mini-map {
+            position: fixed;
+            bottom: 40px;
+            right: 40px;
+            width: 200px;
+            height: 200px;
+            background: rgba(0, 0, 0, 0.95);
+            border: 2px solid var(--burnt-orange);
+            border-radius: 15px;
+            padding: 10px;
+            z-index: 100;
+            display: none; /* Hidden by default */
+        }
+
+        .mini-map canvas {
+            width: 100%;
+            height: 100%;
+            border-radius: 10px;
+        }
+        
+        @media (max-width: 768px) {
+            .mini-map { display: none; }
+        }
+
+        /* Success Message */
+        .success-message {
+            position: fixed;
+            top: 100px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(16, 185, 129, 0.2);
+            border: 1px solid var(--success-green);
+            color: var(--success-green);
+            padding: 15px 30px;
+            border-radius: 50px;
+            font-weight: 600;
+            z-index: 10000;
+            opacity: 0;
+            transition: opacity 0.5s ease;
+            pointer-events: none;
+        }
+        .success-message.visible {
+            opacity: 1;
+        }
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 16px;
+            background: var(--burnt-orange);
+            color: var(--white);
+            padding: 8px 16px;
+            border-radius: 8px;
+            font-weight: 600;
+            text-decoration: none;
+            z-index: 10000;
+            transition: top 0.2s ease;
+        }
+
+        .skip-link:focus {
+            top: 16px;
+        }
+    </style>
+</head>
+<body>
+<a href="#main-dashboard" class="skip-link">Skip to main content</a>
+<header style="position:sticky;top:0;background:#0b0f1a;color:white;padding:12px 16px;display:flex;gap:16px;align-items:center;z-index:9999;box-shadow:0 2px 8px rgba(0,0,0,.2)">
+  <div style="font-weight:700;letter-spacing:.6px">🔥 Blaze Intelligence</div>
+  <nav style="display:flex;gap:14px;font-weight:600">
+    <a href="/" style="color:#E2E8F0;text-decoration:none">Home</a>
+    <a href="/hq" style="color:#E2E8F0;text-decoration:none">HQ</a>
+    <a href="/vision" style="color:#E2E8F0;text-decoration:none">Vision</a>
+    <a href="/public" style="color:#E2E8F0;text-decoration:none">Public</a>
+  </nav>
+</header>
+
+    <main id="main-dashboard">
+    <!-- Loading Screen -->
+    <div class="loading-screen" id="loadingScreen">
+        <div class="loader"></div>
+        <div class="loading-text">
+            BLAZE INTELLIGENCE<br>
+            <span style="font-size: 0.8rem; font-weight: 400;">Championship Sports MCP</span>
+        </div>
+        <div class="loading-progress">
+            <div class="loading-bar"></div>
+        </div>
+    </div>
+
+    <!-- Professional Header -->
+    <div class="header">
+        <div class="brand-logo" onclick="goHome()">
+            <div class="logo-icon">BI</div>
+            <div>
+                <div class="brand-text">BLAZE INTELLIGENCE</div>
+                <div class="brand-tagline">Where Data Meets Dominance</div>
+            </div>
+        </div>
+        <nav class="nav-menu">
+             <div class="nav-links">
+                <a href="#dashboard" class="nav-item">Dashboard</a>
+                <a href="#scouting" class="nav-item">Scouting</a>
+                <a href="#transfer-portal" class="nav-item">Portal Matrix</a>
+                <a href="#ncaa-live" class="nav-item">NCAA Live</a>
+                <a href="#about-austin" class="nav-item">About Austin</a>
+            </div>
+            <div class="nav-controls-group">
+                <div class="nav-cta-group">
+                    <a href="https://blaze-intelligence.netlify.app/" target="_blank" rel="noopener noreferrer" class="nav-item nav-cta">Unified HQ</a>
+                    <a href="https://blaze-intelligence-main.netlify.app/" target="_blank" rel="noopener noreferrer" class="nav-item nav-cta">Executive</a>
+                    <a href="https://blaze-3d.netlify.app/" target="_blank" rel="noopener noreferrer" class="nav-item nav-cta">Immersive 3D</a>
+                </div>
+                <div class="view-toggle">
+                    <button class="mode-btn" id="mode-btn-3d" onclick="setViewMode('3d', this)" aria-pressed="false">3D Universe</button>
+                    <button class="mode-btn active" id="mode-btn-classic" onclick="setViewMode('classic', this)" aria-pressed="true">Classic View</button>
+                </div>
+            </div>
+        </nav>
+    </div>
+
+    <!-- 3D Universe Container -->
+    <div id="universe-container">
+        <canvas id="universe-canvas"></canvas>
+
+        <!-- HUD Overlay -->
+        <div class="hud-overlay">
+            <!-- Mission Statement Panel -->
+            <div id="missionPanel" class="hud-panel mission-panel visible">
+                <h2 class="mission-title">Our Mission</h2>
+                <p class="mission-text">
+                    Blaze Intelligence transforms college athletics through championship-level data analytics.
+                    We provide SEC programs and elite institutions with the intelligence needed to dominate
+                    in the NIL era.
+                </p>
+                <div class="mission-stats">
+                    <div class="mission-stat">
+                        <div class="mission-stat-value" id="mission-stat-nil">$196M+</div>
+                        <div class="mission-stat-label">SEC NIL Tracked</div>
+                    </div>
+                    <div class="mission-stat">
+                        <div class="mission-stat-value" id="mission-stat-programs">50</div>
+                        <div class="mission-stat-label">Programs Analyzed</div>
+                    </div>
+                    <div class="mission-stat">
+                        <div class="mission-stat-value" id="mission-stat-accuracy">94.6%</div>
+                        <div class="mission-stat-label">Prediction Accuracy</div>
+                    </div>
+                    <div class="mission-stat">
+                        <div class="mission-stat-value" id="mission-stat-championship">78.3%</div>
+                        <div class="mission-stat-label">Avg. Champ Prob.</div>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Biomechanics Panel -->
+            <div id="bioPanel" class="hud-panel biomechanics-panel">
+                <h2 class="biomechanics-title">Live Biomechanics</h2>
+                <div class="bio-metric">
+                    <span class="bio-metric-label">Arm Velocity</span>
+                    <span id="bio-velocity" class="bio-metric-value">0 MPH</span>
+                </div>
+                 <div class="bio-metric">
+                    <span class="bio-metric-label">Torso Rotation</span>
+                    <span id="bio-torso" class="bio-metric-value">0°</span>
+                </div>
+                 <div class="bio-metric">
+                    <span class="bio-metric-label">Shoulder Separation</span>
+                    <span id="bio-shoulder" class="bio-metric-value">0°</span>
+                </div>
+                 <div class="bio-metric">
+                    <span class="bio-metric-label">Kinetic Chain Sync</span>
+                    <span id="bio-sync" class="bio-metric-value">0%</span>
+                </div>
+            </div>
+
+            <!-- Program Detail Panel -->
+            <div id="detailPanel" class="hud-panel detail-panel">
+                <button class="close-btn" onclick="hideDetailPanel()" aria-label="Close detail panel">&times;</button>
+                <div class="detail-header">
+                    <img id="detailLogo" src="" alt="Team Logo" class="detail-logo" onerror="this.src='https://placehold.co/60x60/002244/FFFFFF?text=BI'">
+                    <div>
+                        <h2 id="detailTitle" class="detail-title"></h2>
+                        <p id="detailSubtitle" class="detail-subtitle"></p>
+                    </div>
+                </div>
+                <div class="detail-chart-container">
+                    <canvas id="detailNILChart"></canvas>
+                </div>
+                <div id="detailFactors" class="detail-factors">
+                    <h4>Key NIL Factors</h4>
+                </div>
+            </div>
+
+            <!-- Live Metrics Dashboard -->
+            <div id="live-metrics-panel" class="metrics-dashboard fade-in">
+                <div class="metrics-title">
+                    <div class="live-indicator"></div>
+                    LIVE METRICS
+                </div>
+
+                <div class="metric-item">
+                    <div class="metric-header">
+                        <span class="metric-label">Texas NIL Value</span>
+                        <span class="metric-change positive" id="metric-nil-change">+$0.0M</span>
+                    </div>
+                    <div class="metric-value" id="metric-nil-value">$0.0M</div>
+                </div>
+
+                <div class="metric-item">
+                    <div class="metric-header">
+                        <span class="metric-label">Championship Odds</span>
+                        <span class="metric-change positive" id="metric-odds-change"></span>
+                    </div>
+                    <div class="metric-value" id="metric-odds-value">+0</div>
+                </div>
+
+                <div class="metric-item">
+                    <div class="metric-header">
+                        <span class="metric-label">Injury Risk (Team)</span>
+                        <span class="metric-change negative" id="metric-injury-change"></span>
+                    </div>
+                    <div class="metric-value" id="metric-injury-value">0%</div>
+                </div>
+
+                <div class="metric-item">
+                    <div class="metric-header">
+                        <span class="metric-label">Data Points Analyzed</span>
+                        <span class="metric-change positive">LIVE</span>
+                    </div>
+                    <div class="metric-value" id="dataPointsLive">2.8M+</div>
+                </div>
+            </div>
+
+            <!-- Control Panel -->
+            <div class="control-panel">
+                <button class="control-btn active" onclick="setUniverseMode('explore', this)" aria-pressed="true">Explore</button>
+                <button class="control-btn" onclick="setUniverseMode('analytics', this)" aria-pressed="false">Analytics</button>
+                <button class="control-btn" onclick="setUniverseMode('heatmap', this)" aria-pressed="false">Heat Map</button>
+                <button class="control-btn" onclick="setUniverseMode('connections', this)" aria-pressed="false">Network</button>
+                <button class="control-btn" onclick="setUniverseMode('biomechanics', this)" aria-pressed="false">Biomechanics</button>
+                <button class="control-btn" onclick="toggleFullscreen()">Fullscreen</button>
+            </div>
+
+            <!-- Mini Map -->
+            <div class="mini-map" id="miniMapContainer">
+                <canvas id="miniMapCanvas"></canvas>
+            </div>
+        </div>
+    </div>
+
+    <!-- Classic Dashboard Container -->
+    <div id="classic-container">
+        <div class="classic-dashboard">
+            <section class="deployment-hero">
+                <div class="hero-intro">
+                    <h1 class="deployment-hero-title">Championship Sports Mission Command Platform</h1>
+                    <p class="hero-subtitle">Launch the deployment tailored to your role—from unified HQ operations to executive storytelling and immersive demos.</p>
+                </div>
+                <div class="hero-cta-grid">
+                    <a href="https://blaze-intelligence.netlify.app/" target="_blank" rel="noopener noreferrer" class="hero-cta">
+                        <span class="hero-cta-label">Unified Command Center</span>
+                        <span class="hero-cta-description">Operations-grade dashboard that unifies recruiting, NIL, and performance analytics for daily decision cycles.</span>
+                        <span class="hero-cta-action">Launch Unified HQ</span>
+                    </a>
+                    <a href="https://blaze-intelligence-main.netlify.app/" target="_blank" rel="noopener noreferrer" class="hero-cta hero-cta--main">
+                        <span class="hero-cta-label">Executive Mainline</span>
+                        <span class="hero-cta-description">Investor-ready storyline with curated KPIs, valuations, and go-to-market proof for stakeholders.</span>
+                        <span class="hero-cta-action">Open Executive Main</span>
+                    </a>
+                    <a href="https://blaze-3d.netlify.app/" target="_blank" rel="noopener noreferrer" class="hero-cta hero-cta--3d">
+                        <span class="hero-cta-label">Immersive 3D Showcase</span>
+                        <span class="hero-cta-description">WebGL-powered universe built for live demos, highlight reels, and spatial data exploration.</span>
+                        <span class="hero-cta-action">Enter Immersive 3D</span>
+                    </a>
+                </div>
+            </section>
+
+            <section class="deployment-differentiators">
+                 <h2 class="differentiator-title"><span>Deployment Differentiators</span></h2>
+                <p class="differentiator-subtitle">Quickly compare the value of each environment and guide coaches, executives, or partners into the optimal Netlify experience.</p>
+                <div class="differentiator-grid">
+                    <article class="differentiator-card">
+                        <h3>Unified Command Center</h3>
+                        <p>Purpose-built for coaching staffs and analysts who need always-on situational awareness.</p>
+                        <ul>
+                            <li>Live NIL valuations paired with roster and market context.</li>
+                            <li>Automated alerting across recruiting, transfer, and health signals.</li>
+                            <li>Secure workspace tuned for day-to-day program operations.</li>
+                        </ul>
+                        <a href="https://blaze-intelligence.netlify.app/" target="_blank" rel="noopener noreferrer" class="card-link">Explore Unified HQ</a>
+                    </article>
+                    <article class="differentiator-card differentiator-card--main">
+                        <h3>Executive Mainline</h3>
+                        <p>Delivers the polished narrative for investors, athletic directors, and strategic partners.</p>
+                        <ul>
+                            <li>Narrative-first modules featuring sponsor-ready KPIs.</li>
+                            <li>Conversion-focused experiences for fundraising and media deals.</li>
+                            <li>Executive summary flows with embedded partnership CTAs.</li>
+                        </ul>
+                        <a href="https://blaze-intelligence-main.netlify.app/" target="_blank" rel="noopener noreferrer" class="card-link">Visit Executive Main</a>
+                    </article>
+                    <article class="differentiator-card differentiator-card--3d">
+                        <h3>Immersive 3D Showcase</h3>
+                        <p>Transforms Blaze Intelligence into an interactive universe for events, fan activations, and premium demos.</p>
+                        <ul>
+                            <li>Three.js-powered spatial storytelling with cinematic visuals.</li>
+                            <li>Immersive scenes that spotlight prospects, fans, and donors.</li>
+                            <li>Tap-to-explore overlays synchronized with live performance metrics.</li>
+                        </ul>
+                        <a href="https://blaze-3d.netlify.app/" target="_blank" rel="noopener noreferrer" class="card-link">Launch Immersive 3D</a>
+                    </article>
+                </div>
+            </section>
+
+            <div id="dashboard" class="dashboard-header">
+                <h1 class="dashboard-title">Championship Intelligence Dashboard</h1>
+                <p class="dashboard-subtitle">Real-Time NIL Analytics &amp; Sports Intelligence Platform</p>
+            </div>
+
+            <!-- Key Metrics Grid -->
+            <div class="dashboard-grid">
+                <div class="dashboard-card">
+                    <h3 class="card-title">🏆 SEC NIL Leadership</h3>
+                    <div class="card-content" id="key-insights-content">
+                         <p><strong>Texas:</strong> $22.0M (Arch Manning: $6.8M)</p>
+                        <p><strong>Alabama:</strong> $18.4M (Ryan Williams: $2.6M)</p>
+                        <p><strong>LSU:</strong> $17.9M (+77.2% YoY)</p>
+                        <p><strong>Georgia:</strong> $15.7M (Championship DNA)</p>
+                        <hr style="border-color: rgba(255,255,255,0.1); margin: 15px 0;">
+                        <p>• SEC commands 40% of all FBS NIL spending</p>
+                        <p>• Average top-10 program value: $16.57M</p>
+                    </div>
+                     <button id="generate-insights-btn" class="gemini-btn">
+                        <span>✨ Generate AI Insights</span>
+                        <div class="spinner"></div>
+                    </button>
+                </div>
+
+                <div class="dashboard-card">
+                    <h3 class="card-title">🚀 Strategic Command</h3>
+                    <div class="card-content" id="strategy-content" aria-live="polite">
+                       <p>Leverage generative AI to formulate a data-driven, 12-month strategic plan to boost your program's NIL valuation and competitive edge.</p>
+                    </div>
+                    <button id="generate-strategy-btn" class="gemini-btn">
+                        <span>✨ Generate 12-Month Strategy</span>
+                        <div class="spinner"></div>
+                    </button>
+                </div>
+                
+                <div id="scouting" class="dashboard-card scouting-card">
+                    <h3 class="card-title">🎬 AI Scouting Command</h3>
+                    <div class="video-placeholder"></div>
+                    <div class="card-content" id="scouting-analysis-content" aria-live="polite">
+                       <p>Simulate an AI-driven breakdown of game film. Analyze player mechanics, decision-making, and NFL potential in seconds.</p>
+                    </div>
+                    <button id="analyze-play-btn" class="gemini-btn">
+                        <span>Analyze Play Film</span>
+                        <div class="spinner"></div>
+                    </button>
+                </div>
+                
+                 <!-- NEW: Trade Analyzer Card -->
+                <div id="trade-analyzer" class="dashboard-card">
+                    <h3 class="card-title">📈 AI Trade Analyzer</h3>
+                    <div class="card-content" id="trade-analysis-content" aria-live="polite">
+                       <p>Simulate a high-stakes trade scenario. This model evaluates player value, contract implications, and team impact to provide a data-driven recommendation.</p>
+                    </div>
+                    <button id="analyze-trade-btn" class="gemini-btn">
+                        <span>Analyze Blockbuster Trade</span>
+                        <div class="spinner"></div>
+                    </button>
+                </div>
+
+            </div>
+            
+            <!-- NEW: Live NCAA Scoreboard Section -->
+            <div id="ncaa-live" class="data-table">
+                 <div class="table-header">
+                    <h3 class="table-title">Live NCAA Scoreboard</h3>
+                </div>
+                <div class="ncaa-scoreboard" id="ncaaScoreboardContent">
+                    <p style="padding: 20px;">Fetching live game data...</p>
+                </div>
+            </div>
+
+
+            <!-- Data Table -->
+            <div class="data-table">
+                <div class="table-header">
+                    <h3 class="table-title">Top 10 NIL Programs (2025-26)</h3>
+                </div>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Rank</th>
+                            <th>Program</th>
+                            <th>Total Value</th>
+                            <th>Avg/Scholarship Player</th>
+                            <th>Trend</th>
+                        </tr>
+                    </thead>
+                    <tbody id="nilTableBody">
+                        <!-- Data will be populated here -->
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Charts Section -->
+            <div class="charts-container">
+                <div id="transfer-portal" class="chart-card full-width-chart">
+                    <h3 class="card-title">📊 Interactive Transfer Portal Matrix</h3>
+                    <canvas id="transferPortalChart"></canvas>
+                </div>
+            
+                <div class="chart-card">
+                    <h3 class="card-title">Conference NIL Totals ($M)</h3>
+                    <canvas id="conferenceChart"></canvas>
+                </div>
+
+                <div class="chart-card">
+                    <h3 class="card-title">Year-over-Year Growth</h3>
+                    <canvas id="growthChart"></canvas>
+                </div>
+            </div>
+
+            <!-- About Austin Section -->
+            <div id="about-austin" class="dashboard-card">
+                <h3 class="card-title">👤 About Austin</h3>
+                <div class="card-content">
+                    <p>Hi, I’m <strong>Austin Humphrey</strong>. Born and raised in Memphis, Tennessee—a city built on grit, resilience and heart—I’ve carried that “Grit ’n’ Grind” mindset to Boerne, Texas【533134172736189†L10-L15】. Growing up as a multi‑sport athlete taught me teamwork and discipline, shaping my passion for sports and leadership【533134172736189†L12-L16】.</p>
+                    <p>I’m currently pursuing an <em>Entertainment Business: Sports Management</em> Master of Science at Full Sail University【533134172736189†L2-L16】. Over the next 12 months, my intention is to embrace the program’s challenges and align my professional aspirations with my personal values—balancing ambition, authenticity and perseverance【533134172736189†L35-L46】. Inspired by the grit of Memphis and the growth mindset of Austin, I aim to combine data analytics, AI and sports management to revolutionize collegiate athletics.</p>
+                    <p>This Mastery Journal documents my journey and reflections. Learn more via my full journal linked below.</p>
+                </div>
+                <a href="https://new.express.adobe.com/webpage/hJ7k9WoQYDZRS" target="_blank" rel="noopener noreferrer" class="card-link">View Full Mastery Journal</a>
+            </div>
+
+        </div>
+    </div>
+
+    <!-- Player Card Modal -->
+    <div class="player-card-modal-overlay" id="playerCardModal" aria-hidden="true">
+        <div class="player-card-modal" role="dialog" aria-modal="true" aria-labelledby="playerCardName" aria-describedby="playerCardInfo" tabindex="-1">
+             <button class="close-btn" onclick="hidePlayerCard()" aria-label="Close player details">&times;</button>
+             <div class="player-card-header">
+                <img id="playerCardPhoto" src="https://placehold.co/100x100/002244/FFFFFF?text=BI" alt="Player" class="player-photo">
+                <div>
+                    <h2 id="playerCardName" class="player-name"></h2>
+                    <p id="playerCardInfo" class="player-info"></p>
+                </div>
+             </div>
+             <div class="player-card-body">
+                <div class="radar-chart-container">
+                    <canvas id="playerRadarChart"></canvas>
+                </div>
+                <div class="player-stats">
+                    <h4>Key Intelligence</h4>
+                    <div class="player-stat">
+                        <span class="player-stat-label">NIL Valuation</span>
+                        <span id="playerCardNIL" class="player-stat-value"></span>
+                    </div>
+                    <div class="player-stat">
+                        <span class="player-stat-label">Projected Impact</span>
+                        <span id="playerCardImpact" class="player-stat-value"></span>
+                    </div>
+                     <div class="player-stat">
+                        <span class="player-stat-label">Marketability</span>
+                        <span id="playerCardMarket" class="player-stat-value"></span>
+                    </div>
+                     <div class="player-stat">
+                        <span class="player-stat-label">Recruiting Interest</span>
+                        <span id="playerCardInterest" class="player-stat-value"></span>
+                    </div>
+                </div>
+             </div>
+        </div>
+    </div>
+    </main>
+
+    <!-- Success Message -->
+    <div class="success-message" id="successMessage" aria-live="polite">
+        System Updated Successfully
+    </div>
+
+    <script>
+        // --- Mock API Service Module (Simulated Backend) ---
+        const mockApiService = {
+            _simulateNetwork: (data, delay = 800) => new Promise(resolve => setTimeout(() => resolve(data), delay + Math.random() * 500)),
+
+            getBlazeIntelligence: () => mockApiService._simulateNetwork({ longhorns: 94.6 }),
+            getChampionshipOdds: (league) => mockApiService._simulateNetwork({
+                odds: {
+                    longhorns: { nationalChampionshipOdds: '+750' },
+                    crimsontide: { nationalChampionshipOdds: '+900' },
+                    cardinals: { worldSeriesOdds: '+2200' },
+                    titans: { superBowlOdds: '+4500' },
+                    grizzlies: { nbaChampionshipOdds: '+3000' }
+                }
+            }),
+            getNILValuations: (sport) => mockApiService._simulateNetwork({
+                marketAnalysis: { totalMarketValue: 196000000, texasShare: 0.112 }
+            }),
+            getTeamHealth: (teamId) => mockApiService._simulateNetwork({
+                overview: { healthyPlayers: 81, totalPlayers: 85, averageRiskScore: 12.3 }
+            }),
+            analyzeTrade: (tradeData) => mockApiService._simulateNetwork({
+                analysis: {
+                    valueExchange: { netValue: 3500000 },
+                    aiRecommendation: {
+                        recommendation: 'RECOMMEND TRADE',
+                        confidence: 88,
+                        summary: 'The trade provides significant long-term value by acquiring top prospects while shedding veteran salary. The move aligns with a forward-looking roster strategy.'
+                    }
+                }
+            }),
+            getNCAAScoreboard: () => mockApiService._simulateNetwork({
+                games: [{
+                    game: {
+                        status: 'HALFTIME', clock: '0:00', quarter: 2, conference: 'SEC',
+                        away: { names: { short: 'ALA', full: 'Alabama' }, ranking: 5, score: 14 },
+                        home: { names: { short: 'GA', full: 'Georgia' }, ranking: 3, score: 17 }
+                    }
+                }, {
+                    game: {
+                        status: 'FINAL', clock: '0:00', quarter: 4, conference: 'SEC',
+                        away: { names: { short: 'TEX', full: 'Texas' }, ranking: 2, score: 38 },
+                        home: { names: { short: 'OKLA', full: 'Oklahoma' }, ranking: 12, score: 24 }
+                    }
+                }, {
+                    game: {
+                        status: 'Q3', clock: '7:32', quarter: 3, conference: 'B1G',
+                        away: { names: { short: 'MICH', full: 'Michigan' }, ranking: 4, score: 10 },
+                        home: { names: { short: 'OSU', full: 'Ohio State' }, ranking: 1, score: 13 }
+                    }
+                }]
+            }),
+            callGeminiAPI: (prompt) => {
+                if (prompt.includes('sports analyst for an athletic director')) {
+                    return mockApiService._simulateNetwork(
+                        `\n                        * **Market Dominance:** Texas's $22.0M NIL valuation not only leads the SEC but sets a national benchmark, driven by premier talent like Arch Manning. This creates a powerful recruiting gravity well.\n                        * **Growth Anomaly:** LSU's staggering 77.2% YoY growth indicates a highly effective, aggressive NIL strategy that is rapidly closing the gap with established leaders.\n                        * **Efficiency Signal:** Georgia, while 4th in total value, demonstrates 'Championship DNA' by converting NIL spend into on-field success at an elite rate, suggesting high ROI per dollar.\n                        * **SEC Concentration:** The SEC's control of 40% of all FBS NIL spending solidifies its economic moat, making it increasingly difficult for other conferences to compete for top-tier talent.\n                    `
+                    );
+                }
+                if (prompt.includes('strategic consultant for Texas Longhorns')) {
+                    return mockApiService._simulateNetwork({
+                        plan: [
+                            { title: 'Phase 1 (Q1): Solidify Foundation', description: 'Launch "Horns with Heart 2.0" campaign, focusing on athlete storytelling to deepen booster engagement. Onboard 10 new local businesses to the NIL collective.' },
+                            { title: 'Phase 2 (Q2): Digital Expansion', description: 'Develop an AI-powered platform for athletes to connect with national brands. Partner with 3 tech influencers to amplify the program’s digital footprint.' },
+                            { title: 'Phase 3 (Q3): Pre-Season Apex', description: 'Execute a high-profile, team-wide NIL deal with a major auto or tech brand. Host an exclusive NIL summit for boosters and key players.' },
+                            { title: 'Phase 4 (Q4): In-Season Optimization', description: 'Utilize real-time performance data to create dynamic, performance-based NIL incentives. Launch a targeted campaign to maximize Heisman candidate exposure.' }
+                        ]
+                    });
+                }
+                if (prompt.includes('elite NCAA football scout')) {
+                     return mockApiService._simulateNetwork({
+                        analysis: {
+                            strengths: ["Exceptional arm talent; can make all NFL throws.", "Elite pocket presence; senses pressure and navigates effectively.", "High football IQ; quickly processes defensive schemes."],
+                            improvements: ["Inconsistent accuracy on deep throws under pressure.", "Tendency to hold onto the ball too long, leading to sacks.", "Needs refinement in footwork when throwing on the run."]
+                        }
+                    });
+                }
+                return mockApiService._simulateNetwork('Error: AI analysis not available for this prompt.');
+            }
+        };
+
+
+        // --- Main Application Logic ---
+        // Global Variables
+        let scene, camera, renderer, composer, controls;
+        let miniMapScene, miniMapCamera, miniMapRenderer;
+        let stadiums = [], connections = [], particles = [];
+        let raycaster, mouse;
+        let dataPoints = 2800000;
+        let currentViewMode = 'classic';
+        let currentUniverseMode = 'explore';
+        let animationId;
+        let detailChart;
+        let bioModel, bioModelParts = {};
+        let playerRadarChart;
+
+        // Data
+        const programs = [
+            { name: 'Texas', key: 'longhorns', teamId: 'TEX', sport: 'ncaa', value: 22.0, color: 0xBF5700, position: { x: 0, y: 0, z: 0 }, conference: 'SEC', details: { logoUrl: 'https://a.espncdn.com/i/teamlogos/ncaa/500/251.png', historicalNIL: [8.5, 12.1, 15.8, 22.0], factors: { "Star Player Value": "$6.8M (Arch Manning)", "Media Market Rank": "#7 (Austin-Round Rock)", "Booster Collective": "Texas One Fund (Tier 1)", "Championship Contention": "92% Probability" } } },
+            { name: 'Alabama', key: 'crimsontide', teamId: 'ALA', sport: 'ncaa', value: 18.4, color: 0x9E1B32, position: { x: 500, y: 50, z: -300 }, conference: 'SEC', details: { logoUrl: 'https://a.espncdn.com/i/teamlogos/ncaa/500/333.png', historicalNIL: [9.1, 11.5, 14.2, 18.4], factors: { "Coaching Legacy": "Kalen DeBoer Era", "Draft Pipeline": "Top 3 Annually", "Booster Collective": "Yea Alabama (Tier 1)", "Recruiting Class": "#2 Nationally" } } },
+            { name: 'LSU', key: 'tigers', teamId: 'LSU', sport: 'ncaa', value: 17.9, color: 0x461D7C, position: { x: -400, y: 100, z: 200 }, conference: 'SEC', details: { logoUrl: 'https://a.espncdn.com/i/teamlogos/ncaa/500/99.png', historicalNIL: [6.8, 10.1, 13.5, 17.9], factors: { "Social Media Engagement": "Top 5 Nationally", "Key Players": "Harold Perkins Jr.", "Booster Collective": "Bayou Traditions (Tier 2)", "Fan Base Passion": "Elite" } } },
+            { name: 'Georgia', key: 'bulldogs', teamId: 'GA', sport: 'ncaa', value: 15.7, color: 0xBA0C2F, position: { x: 300, y: -50, z: 400 }, conference: 'SEC', details: { logoUrl: 'https://a.espncdn.com/i/teamlogos/ncaa/500/61.png', historicalNIL: [7.2, 10.9, 13.1, 15.7], factors: { "Championship DNA": "2x Nat'l Champs", "Star Player": "Carson Beck", "Booster Collective": "Classic City Collective", "NFL Development": "Record-breaking drafts" } } },
+            { name: 'Ohio State', key: 'buckeyes', teamId: 'OSU', sport: 'Big Ten', value: 18.3, color: 0xBB0000, position: { x: -600, y: 100, z: -100 }, conference: 'Big Ten', details: { logoUrl: 'https://a.espncdn.com/i/teamlogos/ncaa/500/194.png', historicalNIL: [8.8, 12.4, 15.1, 18.3], factors: { "Transfer Portal Wins": "Caleb Downs, Quinshon Judkins", "Media Value": "Top 3 TV Ratings", "Booster Collective": "THE Foundation", "Brand Recognition": "Global" } } },
+            { name: 'Cardinals', key: 'cardinals', teamId: 'STL', sport: 'mlb', value: 15.0, color: 0xC41E3A, position: {x: -200, y: -150, z: 500 }, conference: 'MLB', details: { logoUrl: 'https://a.espncdn.com/i/teamlogos/mlb/500/stl.png', historicalNIL: [10,12,14,15], factors: { 'Star Players': 'Arenado, Goldschmidt' } } },
+            { name: 'Titans', key: 'titans', teamId: 'TEN', sport: 'nfl', value: 16.5, color: 0x4B92DB, position: {x: 600, y: -50, z: -500 }, conference: 'NFL', details: { logoUrl: 'https://a.espncdn.com/i/teamlogos/nfl/500/ten.png', historicalNIL: [11,13,15,16.5], factors: { 'Key Player': 'Derrick Henry' } } },
+            { name: 'Grizzlies', key: 'grizzlies', teamId: 'MEM', sport: 'nba', value: 14.8, color: 0x5D76A9, position: {x: -700, y: 150, z: 400 }, conference: 'NBA', details: { logoUrl: 'https://a.espncdn.com/i/teamlogos/nba/500/mem.png', historicalNIL: [9,11,13,14.8], factors: { 'Star Player': 'Ja Morant' } } },
+        ];
+        
+        // --- Initialization ---
+        function init() {
+            initClassicView();
+            startDataUpdates();
+            updateAllMetrics(); // Initial data load
+            
+            setTimeout(() => {
+                document.getElementById('loadingScreen').style.opacity = '0';
+                setTimeout(() => { document.getElementById('loadingScreen').style.display = 'none'; }, 500);
+            }, 2000);
+        }
+        
+        // --- 3D UNIVERSE ---
+        async function initUniverse() {
+             if (renderer) return;
+            if (document.fonts && document.fonts.ready) { try { await document.fonts.ready; } catch (_) {} }
+            const container = document.getElementById('universe-container');
+            scene = new THREE.Scene();
+            scene.fog = new THREE.FogExp2(0x000000, 0.00015);
+
+            camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 20000);
+            camera.position.set(0, 500, 1500);
+
+            renderer = new THREE.WebGLRenderer({ canvas: document.getElementById('universe-canvas'), antialias: true, alpha: true, powerPreference: "high-performance" });
+            renderer.setSize(window.innerWidth, window.innerHeight);
+            renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+            renderer.toneMapping = THREE.ACESFilmicToneMapping;
+            renderer.toneMappingExposure = 1.2;
+
+            controls = new THREE.OrbitControls(camera, renderer.domElement);
+            controls.enableDamping = true;
+            controls.dampingFactor = 0.05;
+            controls.maxDistance = 5000;
+            controls.minDistance = 100;
+            controls.autoRotate = !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            controls.autoRotateSpeed = 0.3;
+
+            raycaster = new THREE.Raycaster();
+            mouse = new THREE.Vector2();
+
+            setupPostProcessing();
+            createStarField();
+            createStadiums();
+            createNetworkConnections();
+            createBioModel();
+            setupLighting();
+            initMiniMap();
+
+            animate();
+            
+            renderer.domElement.addEventListener('click', onStadiumClick);
+        }
+
+        function createStadiums() {
+            const stadiumGroup = new THREE.Group();
+            programs.forEach((program, index) => {
+                const group = new THREE.Group();
+                const stadiumGeometry = new THREE.CylinderGeometry(80 + program.value * 2, 60 + program.value * 1.5, 40 + program.value, 32, 1, true);
+                const stadiumMaterial = new THREE.MeshPhysicalMaterial({ color: program.color, metalness: 0.6, roughness: 0.3, emissive: program.color, emissiveIntensity: 0.1 });
+                const stadium = new THREE.Mesh(stadiumGeometry, stadiumMaterial);
+                stadium.name = "stadium_base";
+                group.add(stadium);
+                
+                group.position.set(program.position.x, program.position.y, program.position.z);
+                group.userData = program;
+                group.userData.baseY = program.position.y;
+                group.userData.orbitRadius = Math.sqrt(program.position.x ** 2 + program.position.z ** 2);
+                group.userData.orbitSpeed = 0.0005 / (index + 1);
+                group.userData.angle = Math.atan2(program.position.z, program.position.x);
+
+                stadiumGroup.add(group);
+                stadiums.push(group);
+            });
+            scene.add(stadiumGroup);
+        }
+
+        function createNetworkConnections() {
+            const material = new THREE.LineBasicMaterial({
+                color: 0xffffff,
+                transparent: true,
+                opacity: 0.2,
+                linewidth: 1
+            });
+
+            for(let i = 0; i < stadiums.length; i++) {
+                for (let j = i + 1; j < stadiums.length; j++) {
+                    // Only connect major programs for clarity
+                    if (Math.random() > 0.7) {
+                        const points = [stadiums[i].position, stadiums[j].position];
+                        const geometry = new THREE.BufferGeometry().setFromPoints(points);
+                        const line = new THREE.Line(geometry, material.clone());
+                        line.userData.isConnection = true;
+                        connections.push(line);
+                        scene.add(line);
+                    }
+                }
+            }
+        }
+
+        async function onStadiumClick(event) {
+            event.preventDefault();
+            mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+            mouse.y = - (event.clientY / window.innerHeight) * 2 + 1;
+            raycaster.setFromCamera(mouse, camera);
+
+            const intersects = raycaster.intersectObjects(stadiums, true);
+
+            if (intersects.length > 0) {
+                let clickedObject = intersects[0].object;
+                while (clickedObject.parent && !clickedObject.userData.name) {
+                    clickedObject = clickedObject.parent;
+                }
+                
+                if (clickedObject.userData.name) {
+                    await showDetailPanel(clickedObject.userData);
+                    zoomToStadium(clickedObject);
+                }
+            }
+        }
+        
+        async function showDetailPanel(program) {
+            hideAllPanels();
+            const panel = document.getElementById('detailPanel');
+            document.getElementById('detailLogo').src = program.details.logoUrl;
+            document.getElementById('detailTitle').textContent = program.name;
+            document.getElementById('detailSubtitle').textContent = `$${program.value.toFixed(1)}M NIL Valuation`;
+
+            // Fetch live data for the panel
+            const [oddsData, healthData] = await Promise.all([
+                mockApiService.getChampionshipOdds(program.sport),
+                mockApiService.getTeamHealth(program.teamId)
+            ]);
+
+            const factors = { ...program.details.factors };
+            const oddsKey = program.key;
+            if (oddsData && oddsData.odds && oddsData.odds[oddsKey]) {
+                factors['Championship Odds'] = oddsData.odds[oddsKey].nationalChampionshipOdds || oddsData.odds[oddsKey].worldSeriesOdds || oddsData.odds[oddsKey].superBowlOdds || 'N/A';
+            }
+             if (healthData && healthData.overview) {
+                factors['Team Health'] = `${healthData.overview.healthyPlayers}/${healthData.overview.totalPlayers} Healthy`;
+                factors['Injury Risk'] = `${healthData.overview.averageRiskScore}% (Avg. Score)`;
+            }
+
+            const factorsHtml = Object.entries(factors).map(([key, value]) => `
+                <div class="detail-factor">
+                    <span class="detail-factor-label">${key}</span>
+                    <span class="detail-factor-value">${value}</span>
+                </div>
+            `).join('');
+            document.getElementById('detailFactors').innerHTML = `<h4>Key Intelligence Factors</h4>${factorsHtml}`;
+
+            panel.style.display = 'block';
+            setTimeout(() => panel.classList.add('visible'), 10);
+
+            // Chart logic
+            const ctx = document.getElementById('detailNILChart').getContext('2d');
+            if (detailChart) detailChart.destroy();
+            const color = `#${new THREE.Color(program.color).getHexString()}`;
+            const rgbaColor = `rgba(${new THREE.Color(program.color).r * 255}, ${new THREE.Color(program.color).g * 255}, ${new THREE.Color(program.color).b * 255}, 0.2)`;
+            
+            detailChart = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: ['2022', '2023', '2024', '2025'],
+                    datasets: [{
+                        label: 'NIL Value ($M)',
+                        data: program.details.historicalNIL,
+                        borderColor: color,
+                        backgroundColor: rgbaColor,
+                        tension: 0.4,
+                        fill: true
+                    }]
+                },
+                options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, ticks: { color: '#fff' } }, x: { ticks: { color: '#fff' } } } }
+            });
+        }
+        
+        // --- CLASSIC VIEW & MCP FEATURES ---
+        function initClassicView() {
+            populateNILTable();
+            initCharts();
+            initTransferPortalChart();
+
+            document.getElementById('generate-insights-btn').addEventListener('click', generateAIInsights);
+            document.getElementById('generate-strategy-btn').addEventListener('click', generateAIStrategy);
+            document.getElementById('analyze-play-btn').addEventListener('click', analyzePlay);
+            document.getElementById('analyze-trade-btn').addEventListener('click', analyzeTrade);
+        }
+
+        async function analyzeTrade() {
+            const prompt = `Analyze a blockbuster trade: St. Louis Cardinals trade Paul Goldschmidt to the New York Yankees for two top prospects. Evaluate value, impact, and provide a final recommendation.`;
+            handleAIGeneration('analyze-trade-btn', 'trade-analysis-content', prompt, async (btn, contentDiv) => {
+                const analysis = await mockApiService.analyzeTrade({}); // Pass mock data if needed
+                if (analysis && analysis.analysis) {
+                    const { valueExchange, aiRecommendation } = analysis.analysis;
+                    const netValue = (valueExchange.netValue / 1000000).toFixed(1);
+                    const recommendation = aiRecommendation.recommendation;
+                    const confidence = aiRecommendation.confidence;
+
+                    contentDiv.innerHTML = `
+                        <div class="ai-content">
+                            <h4>Trade Recommendation: <span style="color: ${recommendation.includes('RECOMMEND') ? 'var(--success-green)' : 'var(--error-red)'}">${recommendation}</span></h4>
+                            <p><strong>Confidence:</strong> ${confidence}%</p>
+                            <p><strong>Net Value Gain:</strong> <span style="color: var(--success-green);">$${netValue}M</span></p>
+                            <p><strong>Summary:</strong> ${aiRecommendation.summary}</p>
+                        </div>
+                    `;
+                } else {
+                    contentDiv.innerHTML = '<p style="color: var(--error-red);">Trade analysis failed.</p>';
+                }
+            });
+        }
+
+        async function updateNCAAScoreboard() {
+            const container = document.getElementById('ncaaScoreboardContent');
+            const data = await fetch('/api/scoreboard/ncaa').then(r=>r.json());
+            if (!data || !data.games || data.games.length === 0) {
+                container.innerHTML = '<p style="padding: 20px;">No live NCAA games found.</p>';
+                return;
+            }
+
+            container.innerHTML = data.games.map(gameItem => {
+                const game = gameItem.game;
+                const isTexasGame = game.away.names.short === 'TEX' || game.home.names.short === 'TEX';
+                return `
+                    <div class="ncaa-game ${isTexasGame ? 'blaze-highlight' : ''}">
+                        <div class="ncaa-game-header">
+                            <span>${game.status} - ${game.clock} Q${game.quarter}</span>
+                            <span>${game.conference}</span>
+                        </div>
+                        <div class="ncaa-team">
+                            <span class="ncaa-team-name">
+                                ${game.away.ranking ? `<span class="ncaa-team-rank">#${game.away.ranking}</span>` : ''}
+                                ${game.away.names.full}
+                            </span>
+                            <span class="ncaa-team-score">${game.away.score}</span>
+                        </div>
+                        <div class="ncaa-team">
+                            <span class="ncaa-team-name">
+                                ${game.home.ranking ? `<span class="ncaa-team-rank">#${game.home.ranking}</span>` : ''}
+                                ${game.home.names.full}
+                            </span>
+                            <span class="ncaa-team-score">${game.home.score}</span>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+        }
+
+        async function updateAllMetrics() {
+             const blazeIntel = await mockApiService.getBlazeIntelligence();
+             if (blazeIntel) {
+                document.getElementById('metric-injury-value').textContent = `${(100 - blazeIntel.longhorns).toFixed(1)}%`;
+                document.getElementById('mission-stat-accuracy').textContent = `${blazeIntel.longhorns.toFixed(1)}%`;
+             }
+             
+             const nilData = await mockApiService.getNILValuations('football');
+             if(nilData && nilData.marketAnalysis) {
+                document.getElementById('metric-nil-value').textContent = `$${(nilData.marketAnalysis.totalMarketValue * nilData.marketAnalysis.texasShare / 1000000).toFixed(1)}M`;
+                document.getElementById('mission-stat-nil').textContent = `$${(nilData.marketAnalysis.totalMarketValue / 1000000).toFixed(1)}M+`;
+             }
+
+             const oddsData = await mockApiService.getChampionshipOdds('ncaa');
+             if (oddsData && oddsData.odds && oddsData.odds.longhorns) {
+                document.getElementById('metric-odds-value').textContent = oddsData.odds.longhorns.nationalChampionshipOdds;
+             }
+             
+             updateNCAAScoreboard();
+        }
+        
+        async function generateAIInsights() {
+            const prompt = `Act as a world-class sports analyst for an athletic director, providing concise, high-impact insights on the current SEC NIL landscape based on the provided data. Focus on competitive advantages and strategic threats.`;
+            handleAIGeneration('generate-insights-btn', 'key-insights-content', prompt, (response, div) => {
+                 const insightsHtml = '<ul>' + response.split('*').filter(line => line.trim()).map(line => `<li>${line.trim()}</li>`).join('') + '</ul>';
+                div.innerHTML = `<div class="ai-content">${insightsHtml}</div>`;
+            });
+        }
+
+        async function generateAIStrategy() {
+            const prompt = `As a strategic consultant for Texas Longhorns football, devise a 4-phase, 12-month action plan to increase NIL valuation by 20%. The plan must be specific, actionable, and innovative.`;
+            handleAIGeneration('generate-strategy-btn', 'strategy-content', prompt, (response, div) => {
+                 let strategyHtml = response.plan.map(item => `
+                    <div class="strategy-step">
+                        <h4>${item.title}</h4>
+                        <p>${item.description}</p>
+                    </div>`).join('');
+                div.innerHTML = `<div class="ai-content">${strategyHtml}</div>`;
+            });
+        }
+
+        async function analyzePlay() {
+             const prompt = `Act as an elite NCAA football scout. Analyze film of Arch Manning's post route. Provide 3 key strengths and 3 areas for improvement. Be direct and use professional scouting terminology.`;
+             handleAIGeneration('analyze-play-btn', 'scouting-analysis-content', prompt, (response, div) => {
+                const strengthsHtml = response.analysis.strengths.map(s => `<li class="strength">${s}</li>`).join('');
+                const improvementsHtml = response.analysis.improvements.map(i => `<li class="improvement">${i}</li>`).join('');
+                div.innerHTML = `
+                    <div class="analysis-output">
+                        <h4>Strengths</h4>
+                        <ul>${strengthsHtml}</ul>
+                        <h4>Areas for Improvement</h4>
+                        <ul>${improvementsHtml}</ul>
+                    </div>
+                `;
+             });
+        }
+        
+        async function handleAIGeneration(btnId, contentId, prompt, renderer) {
+            const btn = document.getElementById(btnId);
+            const contentDiv = document.getElementById(contentId);
+            if (!btn || !contentDiv) return;
+
+            btn.disabled = true;
+            btn.classList.add('loading');
+            contentDiv.innerHTML = '<p>Contacting MCP Command...</p>';
+
+            try {
+                if (typeof renderer === 'function' && renderer.length === 2) {
+                     // The new signature for complex rendering
+                    await renderer(btn, contentDiv);
+                } else {
+                    // Legacy for simple text rendering
+                    const response = await mockApiService.callGeminiAPI(prompt);
+                    if (response) {
+                        renderer(response, contentDiv);
+                    } else {
+                        throw new Error('Empty response from AI service');
+                    }
+                }
+            } catch (error) {
+                console.error(`Failed to generate AI content for ${btnId}:`, error);
+                contentDiv.innerHTML = '<p style="color: var(--error-red);">MCP connection failed. Please try again.</p>';
+            } finally {
+                btn.disabled = false;
+                btn.classList.remove('loading');
+            }
+        }
+
+        // Start everything on load
+        window.addEventListener('load', init);
+        
+        // --- 3D and Utility functions ---
+        function setViewMode(mode) {
+            currentViewMode = mode;
+            const universeContainer = document.getElementById('universe-container');
+            const classicContainer = document.getElementById('classic-container');
+            const btn3d = document.getElementById('mode-btn-3d');
+            const btnClassic = document.getElementById('mode-btn-classic');
+
+            if (mode === '3d') {
+                initUniverse();
+                universeContainer.style.display = 'block';
+                classicContainer.style.display = 'none';
+                btn3d.classList.add('active');
+                btnClassic.classList.remove('active');
+            } else {
+                universeContainer.style.display = 'none';
+                classicContainer.style.display = 'block';
+                btn3d.classList.remove('active');
+                btnClassic.classList.add('active');
+            }
+        }
+        
+        function setUniverseMode(mode, btn) {
+            currentUniverseMode = mode;
+            document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            
+            hideAllPanels();
+            document.getElementById('live-metrics-panel').style.display = 'block';
+            document.getElementById('miniMapContainer').style.display = 'block';
+            bioModel.visible = false;
+
+            stadiums.forEach(s => {
+                s.visible = true;
+            });
+            connections.forEach(c => c.visible = mode === 'connections');
+
+            switch(mode) {
+                case 'explore':
+                    document.getElementById('missionPanel').style.display = 'block';
+                    setTimeout(() => document.getElementById('missionPanel').classList.add('visible'), 10);
+                    break;
+                case 'biomechanics':
+                    document.getElementById('bioPanel').style.display = 'block';
+                    setTimeout(() => document.getElementById('bioPanel').classList.add('visible'), 10);
+                    bioModel.visible = true;
+                    stadiums.forEach(s => s.visible = false);
+                    break;
+                case 'analytics':
+                    showDetailPanel(programs.find(p => p.name === 'Texas'));
+                    break;
+                case 'connections':
+                     document.getElementById('missionPanel').style.display = 'block';
+                    setTimeout(() => document.getElementById('missionPanel').classList.add('visible'), 10);
+                    break;
+                default:
+                    document.getElementById('missionPanel').style.display = 'block';
+                    setTimeout(() => document.getElementById('missionPanel').classList.add('visible'), 10);
+            }
+        }
+
+        function setupPostProcessing() {
+            composer = new THREE.EffectComposer(renderer);
+            const renderPass = new THREE.RenderPass(scene, camera);
+            composer.addPass(renderPass);
+
+            const bloomPass = new THREE.UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.5, 0.4, 0.85);
+            bloomPass.threshold = 0.1;
+            bloomPass.strength = 0.5;
+            bloomPass.radius = 0.2;
+            composer.addPass(bloomPass);
+        }
+
+        function createStarField() {
+            const vertices = [];
+            for (let i = 0; i < 20000; i++) {
+                const x = THREE.MathUtils.randFloatSpread(10000);
+                const y = THREE.MathUtils.randFloatSpread(10000);
+                const z = THREE.MathUtils.randFloatSpread(10000);
+                vertices.push(x, y, z);
+            }
+            const geometry = new THREE.BufferGeometry();
+            geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+            const material = new THREE.PointsMaterial({ color: 0x888888, size: 2, transparent: true, opacity: 0.8 });
+            particles = new THREE.Points(geometry, material);
+            scene.add(particles);
+        }
+
+        function createBioModel() {
+            bioModel = new THREE.Group();
+            const material = new THREE.MeshBasicMaterial({ color: 0x9BCBEB });
+            
+            const head = new THREE.Mesh(new THREE.SphereGeometry(15, 16, 16), material);
+            head.position.y = 160;
+            bioModelParts.head = head;
+
+            const torso = new THREE.Mesh(new THREE.CylinderGeometry(5, 5, 60, 8), material);
+            torso.position.y = 110;
+            bioModelParts.torso = torso;
+            
+            const rightArm = new THREE.Mesh(new THREE.CylinderGeometry(4, 4, 50, 8), material);
+            rightArm.position.set(-30, 125, 0);
+            bioModelParts.rightArm = rightArm;
+
+            bioModel.add(head, torso, rightArm);
+            bioModel.visible = false;
+            scene.add(bioModel);
+        }
+
+        function setupLighting() {
+            const ambientLight = new THREE.AmbientLight(0xffffff, 0.3);
+            scene.add(ambientLight);
+            const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+            directionalLight.position.set(1, 1, 1).normalize();
+            scene.add(directionalLight);
+        }
+
+        const clock = new THREE.Clock();
+        function animate() {
+            animationId = requestAnimationFrame(animate);
+            const delta = clock.getDelta();
+            const time = clock.getElapsedTime();
+
+            controls.update();
+            particles.rotation.y += 0.0001;
+
+            stadiums.forEach(stadium => {
+                stadium.userData.angle += stadium.userData.orbitSpeed;
+                stadium.position.x = stadium.userData.orbitRadius * Math.cos(stadium.userData.angle);
+                stadium.position.z = stadium.userData.orbitRadius * Math.sin(stadium.userData.angle);
+                stadium.position.y = stadium.userData.baseY + Math.sin(time * 2 + stadium.userData.angle) * 10;
+            });
+
+            connections.forEach(line => {
+                if(line.visible) {
+                    line.material.opacity = 0.15 + (Math.sin(time * 3 + line.geometry.attributes.position.getX(0)) + 1) / 2 * 0.3;
+                }
+            });
+            
+            updateBioModelAnimation(time);
+
+            composer.render(delta);
+            if (miniMapRenderer) updateMiniMap();
+        }
+        
+        function initMiniMap() {
+            const container = document.getElementById('miniMapContainer');
+            if (!container) return;
+            
+            const canvas = document.getElementById('miniMapCanvas');
+            miniMapScene = scene; // Reuse main scene for simplicity
+            
+            miniMapCamera = new THREE.OrthographicCamera(-1000, 1000, 1000, -1000, 1, 10000);
+            miniMapCamera.position.set(0, 3000, 0);
+            miniMapCamera.lookAt(miniMapScene.position);
+            
+            miniMapRenderer = new THREE.WebGLRenderer({ canvas: canvas, antialias: true, alpha: true });
+            miniMapRenderer.setSize(180, 180);
+        }
+
+        function updateMiniMap() {
+            if (miniMapRenderer) {
+                miniMapRenderer.render(miniMapScene, miniMapCamera);
+            }
+        }
+        
+        function updateBioModelAnimation(time) {
+            if (bioModel.visible) {
+                 const angle = Math.sin(time * 2);
+                 bioModelParts.rightArm.rotation.x = -Math.PI / 2 + angle * 1.5;
+                 bioModelParts.torso.rotation.y = angle * 0.5;
+
+                 document.getElementById('bio-velocity').textContent = `${(85 + angle * 10).toFixed(1)} MPH`;
+                 document.getElementById('bio-torso').textContent = `${(angle * 45).toFixed(1)}°`;
+                 document.getElementById('bio-shoulder').textContent = `${(15 + angle * 5).toFixed(1)}°`;
+                 document.getElementById('bio-sync').textContent = `${(90 - Math.abs(angle) * 15).toFixed(1)}%`;
+            }
+        }
+        
+        function zoomToStadium(stadium) {
+            const targetPosition = new THREE.Vector3().copy(stadium.position);
+            targetPosition.z += 300;
+            targetPosition.y += 100;
+
+            // Rudimentary tweening - for a smoother effect, use a library like GSAP or TWEEN.js
+            const startPosition = camera.position.clone();
+            let progress = 0;
+            const duration = 1; // seconds
+            function tween() {
+                progress += 1/60 / duration;
+                if (progress < 1) {
+                    camera.position.lerpVectors(startPosition, targetPosition, progress);
+                    requestAnimationFrame(tween);
+                } else {
+                    camera.position.copy(targetPosition);
+                }
+            }
+            tween();
+        }
+
+        function hideAllPanels() {
+            document.querySelectorAll('.hud-panel').forEach(panel => {
+                panel.classList.remove('visible');
+                setTimeout(() => panel.style.display = 'none', 500);
+            });
+        }
+        
+        function hideDetailPanel() {
+            const panel = document.getElementById('detailPanel');
+            panel.classList.remove('visible');
+            setTimeout(() => panel.style.display = 'none', 500);
+        }
+
+        function populateNILTable() {
+            const tableBody = document.getElementById('nilTableBody');
+            const sortedPrograms = [...programs]
+                .filter(p => p.conference === 'SEC' || p.conference === 'Big Ten')
+                .sort((a, b) => b.value - a.value)
+                .slice(0, 10);
+
+            tableBody.innerHTML = sortedPrograms.map((p, i) => `
+                <tr>
+                    <td>${i + 1}</td>
+                    <td>${p.name}</td>
+                    <td>$${p.value.toFixed(1)}M</td>
+                    <td>$${(p.value * 1000000 / 85).toFixed(0)}K</td>
+                    <td style="color: var(--success-green);">▲ 12.5%</td>
+                </tr>
+            `).join('');
+        }
+
+        function initCharts() {
+            Chart.defaults.color = '#ccc';
+            Chart.defaults.borderColor = 'rgba(255, 255, 255, 0.1)';
+
+            const createGradient = (ctx, chartArea, color1, color2) => {
+                const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top);
+                gradient.addColorStop(0, color1);
+                gradient.addColorStop(1, color2);
+                return gradient;
+            };
+
+            new Chart(document.getElementById('conferenceChart'), {
+                type: 'bar',
+                data: {
+                    labels: ['SEC', 'Big Ten', 'ACC', 'Big 12', 'Pac-12'],
+                    datasets: [{
+                        label: 'NIL Value ($M)',
+                        data: [196, 175, 110, 95, 80],
+                        backgroundColor: function(context) {
+                            const chart = context.chart;
+                            const {ctx, chartArea} = chart;
+                            if (!chartArea) return null;
+                            return createGradient(ctx, chartArea, 'rgba(191, 87, 0, 0.6)', 'rgba(191, 87, 0, 0.9)');
+                        },
+                        borderColor: 'var(--burnt-orange)',
+                        borderWidth: 2,
+                    }]
+                },
+                options: { plugins: { legend: { display: false } } }
+            });
+
+            new Chart(document.getElementById('growthChart'), {
+                type: 'line',
+                data: {
+                    labels: ['2022', '2023', '2024', '2025'],
+                    datasets: [
+                        { 
+                            label: 'Texas', 
+                            data: [8.5, 12.1, 15.8, 22.0], 
+                            borderColor: '#BF5700',
+                            backgroundColor: 'rgba(191, 87, 0, 0.2)',
+                            fill: true,
+                            tension: 0.4
+                        },
+                        { 
+                            label: 'LSU', 
+                            data: [6.8, 10.1, 13.5, 17.9], 
+                            borderColor: '#461D7C',
+                            backgroundColor: 'rgba(70, 29, 124, 0.2)',
+                            fill: true,
+                            tension: 0.4
+                        }
+                    ]
+                }
+            });
+        }
+        
+        function initTransferPortalChart() {
+            const ctx = document.getElementById('transferPortalChart').getContext('2d');
+            const players = [
+                { x: 95, y: 88, r: 20, label: 'Caleb Downs', color: '#BB0000', photo: 'https://a.espncdn.com/i/headshots/college-football/players/full/4871340.png', pos: 'S', school: 'Ohio State', stats: { nil: '$1.1M', impact: '9.2/10', market: 'High', interest: 'High' }, skills: [9, 7, 8, 9, 6] },
+                { x: 85, y: 92, r: 18, label: 'Quinshon Judkins', color: '#BB0000', photo: 'https://a.espncdn.com/i/headshots/college-football/players/full/4685750.png', pos: 'RB', school: 'Ohio State', stats: { nil: '$980K', impact: '9.5/10', market: 'High', interest: 'High' }, skills: [9, 6, 9, 7, 8] },
+                { x: 60, y: 70, r: 15, label: 'Evan Stewart', color: '#D4A017', photo: 'https://a.espncdn.com/i/headshots/college-football/players/full/4685028.png', pos: 'WR', school: 'Oregon', stats: { nil: '$750K', impact: '8.1/10', market: 'Medium', interest: 'High' }, skills: [8, 9, 6, 8, 7] },
+                { x: 40, y: 55, r: 12, label: 'Dillon Gabriel', color: '#D4A017', photo: 'https://a.espncdn.com/i/headshots/college-football/players/full/4360835.png', pos: 'QB', school: 'Oregon', stats: { nil: '$650K', impact: '7.5/10', market: 'Medium', interest: 'Medium' }, skills: [7, 8, 7, 6, 9] },
+                { x: 75, y: 30, r: 10, label: 'Walter Nolen', color: '#500000', photo: 'https://a.espncdn.com/i/headshots/college-football/players/full/4685019.png', pos: 'DL', school: 'Ole Miss', stats: { nil: '$850K', impact: '8.8/10', market: 'Low', interest: 'High' }, skills: [9, 5, 9, 8, 4] }
+            ];
+
+            const chart = new Chart(ctx, {
+                type: 'bubble',
+                data: {
+                    datasets: players.map(p => ({
+                        label: p.label,
+                        data: [{ x: p.x, y: p.y, r: p.r }],
+                        backgroundColor: p.color + 'BF',
+                        playerData: p
+                    }))
+                },
+                options: {
+                    onClick: (e, elements) => {
+                        if (elements.length > 0) {
+                            const element = elements[0];
+                            const dataset = chart.data.datasets[element.datasetIndex];
+                            showPlayerCard(dataset.playerData);
+                        }
+                    },
+                    plugins: {
+                        tooltip: { callbacks: { label: (c) => c.dataset.label } },
+                        legend: { display: false }
+                    },
+                    scales: {
+                        x: { title: { display: true, text: 'NIL Valuation Score' } },
+                        y: { title: { display: true, text: 'On-Field Impact Score' } }
+                    }
+                }
+            });
+        }
+
+        function showPlayerCard(player) {
+            document.getElementById('playerCardName').textContent = player.label;
+            document.getElementById('playerCardInfo').textContent = `${player.pos} | ${player.school}`;
+            document.getElementById('playerCardPhoto').src = player.photo;
+            document.getElementById('playerCardNIL').textContent = player.stats.nil;
+            document.getElementById('playerCardImpact').textContent = player.stats.impact;
+            document.getElementById('playerCardMarket').textContent = player.stats.market;
+            document.getElementById('playerCardInterest').textContent = player.stats.interest;
+
+            createRadarChart(player.skills);
+
+            const modalOverlay = document.getElementById('playerCardModal');
+            if (modalOverlay) {
+                modalOverlay.style.display = 'flex';
+                modalOverlay.setAttribute('aria-hidden', 'false');
+                const dialog = modalOverlay.querySelector('.player-card-modal');
+                if (dialog) {
+                    dialog.focus();
+                }
+            }
+        }
+
+        function hidePlayerCard() {
+            const modal = document.getElementById('playerCardModal');
+            if (modal) {
+                modal.style.display = 'none';
+                modal.setAttribute('aria-hidden', 'true');
+            }
+        }
+        
+        function createRadarChart(skills) {
+             const ctx = document.getElementById('playerRadarChart').getContext('2d');
+             if (playerRadarChart) playerRadarChart.destroy();
+
+             playerRadarChart = new Chart(ctx, {
+                type: 'radar',
+                data: {
+                    labels: ['Athleticism', 'Technique', 'Production', 'Potential', 'Intangibles'],
+                    datasets: [{
+                        label: 'Player Skills',
+                        data: skills,
+                        backgroundColor: 'rgba(255, 215, 0, 0.2)',
+                        borderColor: 'var(--championship-gold)',
+                        borderWidth: 2,
+                        pointBackgroundColor: 'var(--championship-gold)'
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: { legend: { display: false } },
+                    scales: {
+                        r: {
+                            angleLines: { color: 'rgba(255, 255, 255, 0.2)' },
+                            grid: { color: 'rgba(255, 255, 255, 0.2)' },
+                            pointLabels: { color: '#fff', font: { size: 12 } },
+                            ticks: {
+                                backdropColor: 'transparent',
+                                color: '#fff',
+                                stepSize: 2
+                            },
+                            min: 0,
+                            max: 10
+                        }
+                    }
+                }
+             });
+        }
+
+        function startDataUpdates() {
+            setInterval(() => {
+                dataPoints += Math.floor(Math.random() * 5000);
+                document.getElementById('dataPointsLive').textContent = `${(dataPoints / 1000000).toFixed(2)}M+`;
+
+                const currentNil = parseFloat(document.getElementById('metric-nil-value').textContent.replace('$', '').replace('M', ''));
+                const change = (Math.random() * 0.2 - 0.1).toFixed(1);
+                document.getElementById('metric-nil-value').textContent = `$${(currentNil + parseFloat(change)).toFixed(1)}M`;
+                document.getElementById('metric-nil-change').textContent = `${change >= 0 ? '+' : ''}$${change}M`;
+            }, 3000);
+        }
+
+        function goHome() {
+            if (currentViewMode === 'classic') {
+                document.getElementById('classic-container').scrollTo({ top: 0, behavior: 'smooth' });
+            } else {
+                setUniverseMode('explore', document.querySelector('.control-btn'));
+                zoomToStadium({ position: new THREE.Vector3(0, 500, 1500) }); // Reset view
+            }
+        }
+
+        function toggleFullscreen() {
+            if (!document.fullscreenElement) {
+                document.documentElement.requestFullscreen().catch(err => {
+                    alert(`Error attempting to enable full-screen mode: ${err.message} (${err.name})`);
+                });
+            } else {
+                document.exitFullscreen();
+            }
+        }
+
+        function showSuccess(message) {
+            const successMsg = document.getElementById('successMessage');
+            successMsg.textContent = message;
+            successMsg.classList.add('visible');
+            setTimeout(() => {
+                successMsg.classList.remove('visible');
+            }, 3000);
+        }
+        
+        window.addEventListener('resize', () => {
+            if (camera && renderer) {
+                camera.aspect = window.innerWidth / window.innerHeight;
+                camera.updateProjectionMatrix();
+                renderer.setSize(window.innerWidth, window.innerHeight);
+                if (composer) composer.setSize(window.innerWidth, window.innerHeight);
+            }
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === ' ' && currentViewMode === '3d' && controls) {
+                 controls.autoRotate = !controls.autoRotate;
+            }
+            if (e.key === 'Escape') {
+                hideDetailPanel();
+                hidePlayerCard();
+            }
+        });
+
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                if (animationId) {
+                    cancelAnimationFrame(animationId);
+                    animationId = null;
+                }
+            } else if (currentViewMode === '3d' && !animationId) {
+                animate();
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a skip link and semantic main container so keyboard users can jump directly to the dashboard content
- upgrade the player detail modal with ARIA roles, focus management, and labelled controls for better screen reader support
- pause the WebGL animation loop while the tab is hidden and close overlays on Escape for lower background CPU usage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5c930793883308be53893f1240fea